### PR TITLE
feat(api): add production docker-compose with Watchtower

### DIFF
--- a/api/docker-compose.prod.yml
+++ b/api/docker-compose.prod.yml
@@ -1,0 +1,54 @@
+services:
+  api:
+    image: ghcr.io/erikbeerepoot/bramble/api:latest
+    container_name: bramble-api
+    ports:
+      - "5000:5000"
+    devices:
+      - "/dev/ttyAMA0:/dev/ttyAMA0"
+    volumes:
+      - bramble-data:/data
+    environment:
+      - DEBUG=False
+      - SERIAL_PORT=/dev/ttyAMA0
+      - SERIAL_BAUD=115200
+      - HOST=0.0.0.0
+      - PORT=5000
+      - SENSOR_DB_PATH=/data/sensor_data.duckdb
+      - QUEUE_DB_PATH=/data/queue.db
+    restart: unless-stopped
+    group_add:
+      - dialout
+
+  worker:
+    image: ghcr.io/erikbeerepoot/bramble/api:latest
+    container_name: bramble-worker
+    command: uv run huey_consumer command_queue.huey -w 2 -k thread
+    devices:
+      - "/dev/ttyAMA0:/dev/ttyAMA0"
+    volumes:
+      - bramble-data:/data
+    environment:
+      - DEBUG=False
+      - SERIAL_PORT=/dev/ttyAMA0
+      - SERIAL_BAUD=115200
+      - SENSOR_DB_PATH=/data/sensor_data.duckdb
+      - QUEUE_DB_PATH=/data/queue.db
+    restart: unless-stopped
+    depends_on:
+      - api
+    group_add:
+      - dialout
+
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=300  # Check every 5 minutes
+    restart: unless-stopped
+
+volumes:
+  bramble-data:


### PR DESCRIPTION
Add docker-compose.prod.yml that uses pre-built GHCR images instead of building locally. Includes Watchtower for automatic container updates when new images are pushed to the registry.

Usage: docker compose -f docker-compose.prod.yml up -d