### PR TITLE
fix(dashboard): extend chart x-axis to current time for preset ranges

### DIFF
--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -27,6 +27,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onZoneCreated }: NodeDetail
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [timeBounds, setTimeBounds] = useState<{ start: number; end: number } | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -35,13 +36,14 @@ function NodeDetail({ node, zones, onBack, onUpdate, onZoneCreated }: NodeDetail
       let startTime: number | undefined;
       let endTime: number | undefined;
 
+      const now = Math.floor(Date.now() / 1000);
       if (timeRange === 'custom') {
         startTime = customRange.startTime;
         endTime = customRange.endTime;
       } else {
-        const now = Math.floor(Date.now() / 1000);
         const rangeConfig = TIME_RANGES[timeRange];
         startTime = now - rangeConfig.seconds;
+        endTime = now;
       }
 
       const [sensorData, stats] = await Promise.all([
@@ -55,6 +57,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onZoneCreated }: NodeDetail
 
       setReadings(sensorData.readings);
       setStatistics(stats);
+      setTimeBounds({ start: startTime!, end: endTime! });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch data');
     } finally {
@@ -187,6 +190,8 @@ function NodeDetail({ node, zones, onBack, onUpdate, onZoneCreated }: NodeDetail
                   title="Temperature"
                   yAxisLabel="Celsius"
                   color="#f97316"
+                  startTime={timeBounds?.start}
+                  endTime={timeBounds?.end}
                 />
                 <SensorChart
                   readings={readings}
@@ -194,6 +199,8 @@ function NodeDetail({ node, zones, onBack, onUpdate, onZoneCreated }: NodeDetail
                   title="Humidity"
                   yAxisLabel="Percent"
                   color="#3b82f6"
+                  startTime={timeBounds?.start}
+                  endTime={timeBounds?.end}
                 />
               </div>
             )}

--- a/dashboard/src/components/SensorChart.tsx
+++ b/dashboard/src/components/SensorChart.tsx
@@ -7,9 +7,11 @@ interface SensorChartProps {
   title: string;
   yAxisLabel: string;
   color: string;
+  startTime?: number;  // Unix timestamp
+  endTime?: number;    // Unix timestamp
 }
 
-function SensorChart({ readings, dataKey, title, yAxisLabel, color }: SensorChartProps) {
+function SensorChart({ readings, dataKey, title, yAxisLabel, color, startTime, endTime }: SensorChartProps) {
   // Sort readings by timestamp (oldest first for proper line chart)
   const sortedReadings = [...readings].sort((a, b) => a.timestamp - b.timestamp);
 
@@ -56,9 +58,12 @@ function SensorChart({ readings, dataKey, title, yAxisLabel, color }: SensorChar
             type: 'date',
             tickformat: '%H:%M\n%b %d',
             gridcolor: '#f3f4f6',
+            range: startTime && endTime
+              ? [new Date(startTime * 1000), new Date(endTime * 1000)]
+              : undefined,
           },
           yaxis: {
-            title: yAxisLabel,
+            title: { text: yAxisLabel },
             gridcolor: '#f3f4f6',
           },
           paper_bgcolor: 'transparent',


### PR DESCRIPTION
Previously, the chart x-axis ended at the timestamp of the last sensor reading. If a sensor hadn't emitted data recently, the chart appeared to end in the past rather than at the current time.

Changes:
- Add startTime/endTime props to SensorChart component
- Set explicit xaxis.range in Plotly layout when bounds are provided
- Calculate endTime=now for preset time ranges (1h, 6h, 24h, 7d, 30d)
- Store and pass time bounds from NodeDetail to SensorChart
- Fix yaxis.title TypeScript type (use object format)