### PR TITLE
fix(pmu): use HSI clock for LPUART and increase baud to 9600

### DIFF
--- a/pmu-stm32/Core/Src/main.cpp
+++ b/pmu-stm32/Core/Src/main.cpp
@@ -279,9 +279,10 @@ void SystemClock_Config(void)
     Error_Handler();
   }
   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_LPUART1|RCC_PERIPHCLK_RTC;
-  // Use PCLK1 (2.097 MHz from MSI) for LPUART - HAL will calculate correct BRR
-  // This avoids HSI clock source issues and provides a known working configuration
-  PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PCLK1;
+  // Use HSI (16 MHz) for LPUART - more accurate than MSI-derived PCLK1
+  // HSI is factory-calibrated with ±1% accuracy over temperature range
+  // MSI has wider tolerance which caused baud rate to be ~7.5% off (2218 instead of 2400)
+  PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_HSI;
   PeriphClkInit.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
   if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
   {
@@ -305,7 +306,7 @@ static void MX_LPUART1_UART_Init(void)
 
   /* USER CODE END LPUART1_Init 1 */
   hlpuart1.Instance = LPUART1;
-  hlpuart1.Init.BaudRate = 2400;  // Slower rate for better stability
+  hlpuart1.Init.BaudRate = 9600;  // Standard rate, requires HSI (16 MHz) clock source
   hlpuart1.Init.WordLength = UART_WORDLENGTH_8B;
   hlpuart1.Init.StopBits = UART_STOPBITS_2;  // 2 stop bits for better timing margin
   hlpuart1.Init.Parity = UART_PARITY_NONE;

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -33,7 +33,7 @@ void IrrigationMode::onStart() {
     // TODO: Re-enable after UART debug testing - GPIO24 conflict
     // valve_controller_.initialize();
 
-    // Initialize PMU client
+    // Initialize PMU client at 9600 baud to match STM32 LPUART configuration
     pmu_client_ = new PmuClient(PMU_UART_ID, PMU_UART_TX_PIN, PMU_UART_RX_PIN, 9600);
     pmu_available_ = pmu_client_->init();
 

--- a/src/modes/sensor_mode.cpp
+++ b/src/modes/sensor_mode.cpp
@@ -71,8 +71,8 @@ void SensorMode::onStart() {
     // Red single channel at full brightness for power efficiency
     operational_pattern_ = std::make_unique<ShortBlinkPattern>(led_, 255, 0, 0);
 
-    // Initialize PMU client at 2200 baud (measured actual STM32 rate from logic analyzer)
-    pmu_client_ = new PmuClient(PMU_UART_ID, PMU_UART_TX_PIN, PMU_UART_RX_PIN, 2200);
+    // Initialize PMU client at 9600 baud to match STM32 LPUART configuration
+    pmu_client_ = new PmuClient(PMU_UART_ID, PMU_UART_TX_PIN, PMU_UART_RX_PIN, 9600);
     pmu_available_ = pmu_client_->init();
 
     if (pmu_available_) {


### PR DESCRIPTION
The STM32 LPUART was using PCLK1 (derived from MSI oscillator) as its clock source. The MSI oscillator was running ~7.5% slow, causing the actual baud rate to be 2218 instead of the configured 2400.

Changed LPUART clock source to HSI (16 MHz), which is factory-calibrated with ±1% accuracy over the full temperature range.

Also increased baud rate from 2400 to 9600:
- 2400 baud is below the minimum supported rate for 16 MHz HSI (BRR would exceed LPUART_BRR_MAX of 0xFFFFF)
- 9600 is a standard rate and 4x faster

Updated Pico-side baud rates in sensor_mode and irrigation_mode to match.