### PR TITLE
fix(storage): correct sector erase logic for non-aligned records

### DIFF
--- a/src/storage/sensor_flash_buffer.h
+++ b/src/storage/sensor_flash_buffer.h
@@ -180,6 +180,7 @@ private:
     ExternalFlash& flash_;
     SensorFlashMetadata metadata_;
     bool initialized_;
+    bool first_write_since_boot_;  // Track if we need to erase on first write
     Logger logger_;
 
     // Sector buffer for read-modify-write operations


### PR DESCRIPTION
Records (12 bytes) don't align with sector boundaries (4096 bytes), causing sectors beyond the first to never be erased. The old logic only erased when record_offset_in_sector == 0, but no record after the first sector starts at offset 0.

This caused all writes to non-erased sectors to produce corrupt data (NOR flash can only flip 1s to 0s without erasure), resulting in CRC mismatches on every read.

Changes:
- Erase sector when entering a new sector (based on where previous record ended), not just when starting at offset 0
- Handle records that span two sectors
- Always erase target sector(s) on first write after boot to handle stale data from previous sessions