### PR TITLE
fix(watchtower): add ghcr.io credentials for private image pulls

### DIFF
--- a/api/docker-compose.prod.yml
+++ b/api/docker-compose.prod.yml
@@ -45,7 +45,9 @@ services:
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.docker/config.json:/config.json:ro
     environment:
+      - DOCKER_CONFIG=/
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=300  # Check every 5 minutes
     restart: unless-stopped


### PR DESCRIPTION
Mount Docker config.json into Watchtower container and set DOCKER_CONFIG environment variable so it can authenticate with GitHub Container Registry.