### PR TITLE
fix(storage): remove first-write-after-boot erase that corrupted data

### DIFF
--- a/src/storage/sensor_flash_buffer.h
+++ b/src/storage/sensor_flash_buffer.h
@@ -180,7 +180,6 @@ private:
     ExternalFlash& flash_;
     SensorFlashMetadata metadata_;
     bool initialized_;
-    bool first_write_since_boot_;  // Track if we need to erase on first write
     Logger logger_;
 
     // Sector buffer for read-modify-write operations


### PR DESCRIPTION
The first-write-after-boot logic was erasing the entire sector on each boot, destroying valid records from previous sessions. This caused all but the most recent record to fail CRC checks.

Changes:
- Remove first_write_since_boot_ flag and associated logic
- Only erase when actually crossing into a new sector
- Add write verification (read-back CRC check after each write)
- Add debug logging for erase and write operations

The sector-crossing erase logic correctly handles:
- First record ever (write_index == 0): erase first data sector
- Subsequent records: erase only when entering a new sector
- Records spanning two sectors: erase both sectors