### PR TITLE
refactor(pmu): separate wake callbacks for sensor vs irrigation modes

### DIFF
--- a/src/modes/sensor_mode.h
+++ b/src/modes/sensor_mode.h
@@ -82,11 +82,12 @@ private:
     void signalReadyForSleep();
 
     /**
-     * @brief Handle PMU wake notification
-     * @param reason Wake reason from PMU
-     * @param entry Schedule entry (if scheduled wake)
+     * @brief Handle PMU wake notification (periodic/external only)
+     * @param reason Wake reason from PMU (Periodic or External)
+     *
+     * Scheduled wakes are handled by IrrigationMode, not SensorMode.
      */
-    void handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEntry* entry);
+    void handlePmuWake(PMU::WakeReason reason);
 
     /**
      * @brief Handle heartbeat response - sync time to PMU


### PR DESCRIPTION
SensorMode was receiving ScheduleEntry data (valveId, duration, etc.) even though it doesn't perform irrigation. This was an anti-pattern where sensor code had to deal with irrigation-specific types.

Changes:
- Add PeriodicWakeCallback for modes that only need periodic/external wakes
- Add ScheduledWakeCallback for irrigation modes that need schedule entry data
- Update SensorMode to use onPeriodicWake() without ScheduleEntry parameter
- Keep legacy onWake() for backwards compatibility
- IrrigationMode continues using protocol.onWakeNotification() directly

This improves separation of concerns between sensor and irrigation modes.