### PR TITLE
ci(firmware): remove PR trigger from firmware build workflow

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -11,12 +11,6 @@ on:
       - '.github/workflows/firmware-build.yml'
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'pmu-stm32/**'
-      - 'CMakeLists.txt'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Firmware images will now only build on merges to main, version tags, releases, and manual dispatch. This reduces CI costs by skipping firmware builds on pull requests.