### PR TITLE
feat(dashboard): add URL-based routing with react-router-dom

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11,7 +11,8 @@
         "plotly.js": "^2.27.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-plotly.js": "^2.6.0"
+        "react-plotly.js": "^2.6.0",
+        "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -2115,6 +2116,18 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4400,6 +4413,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4719,6 +4768,11 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/shallow-copy": {
       "version": "0.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,7 +13,8 @@
     "plotly.js": "^2.27.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-plotly.js": "^2.6.0"
+    "react-plotly.js": "^2.6.0",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/dashboard/src/components/NodeDetailPage.tsx
+++ b/dashboard/src/components/NodeDetailPage.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import type { Node } from '../types';
+import { useAppContext } from '../App';
+import { getNode } from '../api/client';
+import NodeDetail from './NodeDetail';
+
+function NodeDetailPage() {
+  const { address } = useParams<{ address: string }>();
+  const navigate = useNavigate();
+  const { nodes, zones, updateNode, addZone } = useAppContext();
+  const [node, setNode] = useState<Node | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadNode() {
+      if (!address) {
+        setError('No node address provided');
+        setLoading(false);
+        return;
+      }
+
+      const addressNum = parseInt(address, 10);
+      if (isNaN(addressNum)) {
+        setError('Invalid node address');
+        setLoading(false);
+        return;
+      }
+
+      // First try to find the node in the cached list
+      const cachedNode = nodes.find(n => n.address === addressNum);
+      if (cachedNode) {
+        setNode(cachedNode);
+        setLoading(false);
+        return;
+      }
+
+      // If not in cache, fetch from API
+      try {
+        const fetchedNode = await getNode(addressNum);
+        setNode(fetchedNode);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load node');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadNode();
+  }, [address, nodes]);
+
+  // Update local node state when it changes in the nodes list
+  useEffect(() => {
+    if (node && address) {
+      const addressNum = parseInt(address, 10);
+      const updatedNode = nodes.find(n => n.address === addressNum);
+      if (updatedNode) {
+        setNode(updatedNode);
+      }
+    }
+  }, [nodes, address, node]);
+
+  const handleBack = () => {
+    navigate('/nodes');
+  };
+
+  const handleUpdate = (updatedNode: Node) => {
+    setNode(updatedNode);
+    updateNode(updatedNode);
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center py-12">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-bramble-600 border-t-transparent"></div>
+        <p className="mt-2 text-gray-600">Loading node...</p>
+      </div>
+    );
+  }
+
+  if (error || !node) {
+    return (
+      <div className="card bg-red-50 border border-red-200">
+        <p className="text-red-700">Error: {error || 'Node not found'}</p>
+        <button
+          onClick={handleBack}
+          className="mt-2 btn btn-primary"
+        >
+          Back to Nodes
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <NodeDetail
+      node={node}
+      zones={zones}
+      onBack={handleBack}
+      onUpdate={handleUpdate}
+      onZoneCreated={addZone}
+    />
+  );
+}
+
+export default NodeDetailPage;

--- a/dashboard/src/components/NodeList.tsx
+++ b/dashboard/src/components/NodeList.tsx
@@ -1,21 +1,17 @@
 import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Node, Zone } from '../types';
+import { useAppContext } from '../App';
 import NodeCard from './NodeCard';
-
-interface NodeListProps {
-  nodes: Node[];
-  zones: Zone[];
-  onSelect: (node: Node) => void;
-  onRefresh: () => void;
-  refreshing?: boolean;
-}
 
 interface ZoneGroup {
   zone: Zone | null;
   nodes: Node[];
 }
 
-function NodeList({ nodes, zones, onSelect, onRefresh, refreshing }: NodeListProps) {
+function NodeList() {
+  const { nodes, zones, loading, refreshing, error, fetchNodes } = useAppContext();
+  const navigate = useNavigate();
   const [collapsedZones, setCollapsedZones] = useState<Set<number | 'unzoned'>>(new Set());
 
   const onlineNodes = nodes.filter(n => n.online);
@@ -88,6 +84,33 @@ function NodeList({ nodes, zones, onSelect, onRefresh, refreshing }: NodeListPro
     return zone?.id ?? 'unzoned';
   };
 
+  const handleNodeSelect = (node: Node) => {
+    navigate(`/nodes/${node.address}`);
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center py-12">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-bramble-600 border-t-transparent"></div>
+        <p className="mt-2 text-gray-600">Loading nodes...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card bg-red-50 border border-red-200">
+        <p className="text-red-700">Error: {error}</p>
+        <button
+          onClick={fetchNodes}
+          className="mt-2 btn btn-primary"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -98,7 +121,7 @@ function NodeList({ nodes, zones, onSelect, onRefresh, refreshing }: NodeListPro
           </p>
         </div>
         <button
-          onClick={onRefresh}
+          onClick={fetchNodes}
           disabled={refreshing}
           className="btn btn-secondary flex items-center space-x-2"
         >
@@ -163,7 +186,7 @@ function NodeList({ nodes, zones, onSelect, onRefresh, refreshing }: NodeListPro
                         key={node.address}
                         node={node}
                         zone={group.zone ?? undefined}
-                        onClick={() => onSelect(node)}
+                        onClick={() => handleNodeSelect(node)}
                       />
                     ))}
                   </div>

--- a/dashboard/src/components/Settings.tsx
+++ b/dashboard/src/components/Settings.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getApiUrl, setApiUrl, checkHealth } from '../api/client';
+import { useAppContext } from '../App';
 
-interface SettingsProps {
-  onSave: () => void;
-}
-
-function Settings({ onSave }: SettingsProps) {
+function Settings() {
+  const navigate = useNavigate();
+  const { fetchNodes } = useAppContext();
   const [url, setUrl] = useState(getApiUrl());
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -36,9 +36,10 @@ function Settings({ onSave }: SettingsProps) {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     setApiUrl(url);
-    onSave();
+    await fetchNodes();
+    navigate('/nodes');
   };
 
   return (

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './routes'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 )

--- a/dashboard/src/routes.tsx
+++ b/dashboard/src/routes.tsx
@@ -1,0 +1,30 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import App from './App';
+import NodeList from './components/NodeList';
+import NodeDetailPage from './components/NodeDetailPage';
+import Settings from './components/Settings';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/nodes" replace />,
+      },
+      {
+        path: 'nodes',
+        element: <NodeList />,
+      },
+      {
+        path: 'nodes/:address',
+        element: <NodeDetailPage />,
+      },
+      {
+        path: 'settings',
+        element: <Settings />,
+      },
+    ],
+  },
+]);


### PR DESCRIPTION
Page reloads now preserve navigation state. URLs reflect the current view:
- / redirects to /nodes
- /nodes shows node list
- /nodes/:address shows node detail
- /settings shows settings page

Browser back/forward navigation works correctly.