### PR TITLE
fix(api): cap DuckDB memory to prevent OOM kills on Pi

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -20,6 +20,8 @@ class Config:
 
     # Database settings
     SENSOR_DB_PATH = os.getenv('SENSOR_DB_PATH', '/data/sensor_data.duckdb')
+    DB_MEMORY_LIMIT = os.getenv('DB_MEMORY_LIMIT', '128MB')  # DuckDB memory limit (default 75% RAM is too aggressive for Pi)
+    DB_THREADS = int(os.getenv('DB_THREADS', '2'))  # DuckDB worker threads
     DB_BATCH_SIZE = int(os.getenv('DB_BATCH_SIZE', '100'))  # Records per batch insert
     DB_FLUSH_INTERVAL = float(os.getenv('DB_FLUSH_INTERVAL', '5.0'))  # Seconds between buffer flushes
 

--- a/api/database.py
+++ b/api/database.py
@@ -217,7 +217,10 @@ class SensorDatabase:
     @contextmanager
     def _get_connection(self):
         """Context manager for database connections."""
-        conn = duckdb.connect(self.db_path)
+        conn = duckdb.connect(self.db_path, config={
+            'memory_limit': Config.DB_MEMORY_LIMIT,
+            'threads': Config.DB_THREADS,
+        })
         try:
             yield conn
         finally:

--- a/api/docker-compose.prod.yml
+++ b/api/docker-compose.prod.yml
@@ -16,6 +16,8 @@ services:
       - PORT=5000
       - SENSOR_DB_PATH=/data/sensor_data.duckdb
       - QUEUE_DB_PATH=/data/queue.db
+      - DB_MEMORY_LIMIT=128MB
+      - DB_THREADS=2
     restart: unless-stopped
     group_add:
       - dialout


### PR DESCRIPTION
DuckDB defaults to 75% of system RAM, which causes the kernel OOM killer to terminate the API container on memory-constrained Pi devices. Caps memory at 128MB and threads at 2, configurable via environment.