### PR TITLE
refactor: remove location field from node metadata

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -277,7 +277,6 @@ def get_node_metadata(address: int):
             return jsonify({
                 'address': address,
                 'name': None,
-                'location': None,
                 'notes': None,
                 'updated_at': None
             })
@@ -297,7 +296,6 @@ def update_node_metadata(address: int):
     Request body:
         {
             "name": "Greenhouse Sensor",
-            "location": "North greenhouse, row 3",
             "notes": "Replaced battery 2024-01"
         }
 
@@ -313,7 +311,6 @@ def update_node_metadata(address: int):
         metadata = db.update_node_metadata(
             address=address,
             name=data.get('name'),
-            location=data.get('location'),
             notes=data.get('notes')
         )
 

--- a/api/models.py
+++ b/api/models.py
@@ -59,10 +59,9 @@ class Node:
 
 @dataclass
 class NodeMetadata:
-    """Metadata for a LoRa node (friendly name, location, notes)."""
+    """Metadata for a LoRa node (friendly name, notes)."""
     address: int
     name: Optional[str] = None
-    location: Optional[str] = None
     notes: Optional[str] = None
     zone_id: Optional[int] = None
     updated_at: Optional[int] = None
@@ -72,7 +71,6 @@ class NodeMetadata:
         return {
             'address': self.address,
             'name': self.name,
-            'location': self.location,
             'notes': self.notes,
             'zone_id': self.zone_id,
             'updated_at': self.updated_at

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -60,7 +60,7 @@ export async function getNodeMetadata(address: number): Promise<NodeMetadata> {
 
 export async function updateNodeMetadata(
   address: number,
-  metadata: Partial<Pick<NodeMetadata, 'name' | 'location' | 'notes'>>
+  metadata: Partial<Pick<NodeMetadata, 'name' | 'notes'>>
 ): Promise<NodeMetadata> {
   return fetchApi<NodeMetadata>(`/api/nodes/${address}/metadata`, {
     method: 'PUT',

--- a/dashboard/src/components/NodeCard.tsx
+++ b/dashboard/src/components/NodeCard.tsx
@@ -59,11 +59,6 @@ function NodeCard({ node, zone, onClick }: NodeCardProps) {
             <p className="text-sm text-gray-500">Address: {node.address}</p>
           )}
 
-          {node.metadata?.location && (
-            <p className="text-sm text-gray-500 mt-1 truncate">
-              {node.metadata.location}
-            </p>
-          )}
         </div>
 
         {/* Overall health indicator */}

--- a/dashboard/src/components/NodeNameEditor.tsx
+++ b/dashboard/src/components/NodeNameEditor.tsx
@@ -13,7 +13,6 @@ interface NodeNameEditorProps {
 function NodeNameEditor({ node, zones, onUpdate, onZoneCreated }: NodeNameEditorProps) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(node.metadata?.name || '');
-  const [location, setLocation] = useState(node.metadata?.location || '');
   const [notes, setNotes] = useState(node.metadata?.notes || '');
   const [selectedZoneId, setSelectedZoneId] = useState<number | null>(node.metadata?.zone_id ?? null);
   const [saving, setSaving] = useState(false);
@@ -35,7 +34,6 @@ function NodeNameEditor({ node, zones, onUpdate, onZoneCreated }: NodeNameEditor
       // Update other metadata
       const updated = await updateNodeMetadata(node.address, {
         name: name || null,
-        location: location || null,
         notes: notes || null,
       });
       onUpdate(updated);
@@ -49,7 +47,6 @@ function NodeNameEditor({ node, zones, onUpdate, onZoneCreated }: NodeNameEditor
 
   const handleCancel = () => {
     setName(node.metadata?.name || '');
-    setLocation(node.metadata?.location || '');
     setNotes(node.metadata?.notes || '');
     setSelectedZoneId(node.metadata?.zone_id ?? null);
     setEditing(false);
@@ -94,10 +91,6 @@ function NodeNameEditor({ node, zones, onUpdate, onZoneCreated }: NodeNameEditor
                 <span className="text-gray-400 italic">Not assigned</span>
               )}
             </dd>
-          </div>
-          <div>
-            <dt className="text-sm text-gray-500">Location</dt>
-            <dd className="text-gray-900">{node.metadata?.location || <span className="text-gray-400 italic">Not set</span>}</dd>
           </div>
           <div>
             <dt className="text-sm text-gray-500">Notes</dt>
@@ -185,20 +178,6 @@ function NodeNameEditor({ node, zones, onUpdate, onZoneCreated }: NodeNameEditor
               <span>{zones.find(z => z.id === selectedZoneId)?.name}</span>
             </div>
           )}
-        </div>
-
-        <div>
-          <label htmlFor="location" className="block text-sm font-medium text-gray-700 mb-1">
-            Location
-          </label>
-          <input
-            id="location"
-            type="text"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="e.g., North greenhouse, row 3"
-            className="input w-full"
-          />
         </div>
 
         <div>

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -13,7 +13,6 @@ export interface ZonesResponse {
 export interface NodeMetadata {
   address: number;
   name: string | null;
-  location: string | null;
   notes: string | null;
   zone_id: number | null;
   updated_at: number | null;


### PR DESCRIPTION
Location was unused and redundant with zone-based organization. Removes from frontend (NodeNameEditor, NodeCard, types, API client) and backend (models, database queries, API endpoints). The column remains in existing DuckDB databases but is no longer read or written.