### PR TITLE
fix(build): suppress GCC ARM ABI compatibility notes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,9 @@ if(NOT BUILD_TESTS)
             BRAMBLE_VERSION_BUILD=${BRAMBLE_VERSION_BUILD}
         )
 
+        # Suppress GCC ARM ABI notes (safe for standalone firmware)
+        target_compile_options(${TARGET_NAME} PRIVATE -Wno-psabi)
+
         # Libraries and configuration for the target
         target_link_libraries(${TARGET_NAME} pico_stdlib)
 


### PR DESCRIPTION
Add -Wno-psabi flag to suppress GCC 7.1 ARM ABI notes about std::map iterator parameter passing changes. These notes are purely informational and not relevant for standalone firmware that compiles all code together with the same compiler.