### PR TITLE
fix: arm valve auto-close timer on cold-boot Scheduled wake

### DIFF
--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -215,6 +215,7 @@ void IrrigationMode::onStateChange(IrrigationState state)
                     valve_duration_seconds_, pending_close_valve_id_,
                     [this](bool success, PMU::ErrorCode error) {
                         if (success) {
+                            valve_timer_armed_ = true;
                             event_log_.record(EventType::VALVE_TIMER_SET, 0,
                                               pending_close_valve_id_);
                             irrigation_state_.reportValveTimerSet();
@@ -326,6 +327,7 @@ void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEn
         pending_valve_close_ = false;
         pending_close_valve_id_ = 0;
         valve_duration_seconds_ = 0;
+        valve_timer_armed_ = false;
     }
 
     // For scheduled wakes, open the valve and set up timer-driven close
@@ -339,6 +341,7 @@ void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEn
                 pending_valve_close_ = true;
                 pending_close_valve_id_ = entry->valveId;
                 valve_duration_seconds_ = entry->duration;
+                valve_timer_armed_ = false;  // PMU timer not yet set; will arm in VALVE_ACTIVE
             }
         } else {
             logger.error("Invalid valve ID %d in schedule", entry->valveId);
@@ -609,6 +612,15 @@ void IrrigationMode::onUpdateFailed()
 
 void IrrigationMode::onUpdateReceived(bool has_updates)
 {
+    // If we just opened a valve via Scheduled wake but haven't armed the PMU
+    // close timer yet, detour through VALVE_ACTIVE to set it up before sleeping.
+    // (The cold-boot path in handlePmuWake doesn't go through VALVE_ACTIVE on
+    // its own — see reportWakeFromSleep is bypassed when state==INITIALIZING.)
+    if (!has_updates && pending_valve_close_ && !valve_timer_armed_) {
+        logger.info("Pending valve close needs PMU timer setup - entering VALVE_ACTIVE");
+        irrigation_state_.reportValveOpened();
+        return;
+    }
     irrigation_state_.reportUpdateReceived(has_updates);
 }
 
@@ -675,6 +687,8 @@ void IrrigationMode::packState(IrrigationPersistedState &out) const
     }
     out.pending_valve_close = pending_valve_close_ ? 1 : 0;
     out.pending_close_valve_id = pending_close_valve_id_;
+    out.valve_timer_armed = valve_timer_armed_ ? 1 : 0;
+    out.valve_duration_seconds = valve_duration_seconds_;
 }
 
 bool IrrigationMode::unpackState(const IrrigationPersistedState *persisted)
@@ -720,10 +734,13 @@ bool IrrigationMode::unpackState(const IrrigationPersistedState *persisted)
     // Restore pending valve close state
     pending_valve_close_ = (persisted->pending_valve_close != 0);
     pending_close_valve_id_ = persisted->pending_close_valve_id;
+    valve_timer_armed_ = (persisted->valve_timer_armed != 0);
+    valve_duration_seconds_ = persisted->valve_duration_seconds;
 
-    pmu_logger.info("Restored state: seq=%u, addr=0x%04X, update_seq=%u, pending_close=%u",
-                    persisted->next_seq_num, persisted->assigned_address,
-                    persisted->update_sequence, persisted->pending_valve_close);
+    pmu_logger.info(
+        "Restored state: seq=%u, addr=0x%04X, update_seq=%u, pending_close=%u, timer_armed=%u",
+        persisted->next_seq_num, persisted->assigned_address, persisted->update_sequence,
+        persisted->pending_valve_close, persisted->valve_timer_armed);
 
     return true;
 }

--- a/src/modes/irrigation_mode.h
+++ b/src/modes/irrigation_mode.h
@@ -25,11 +25,16 @@ struct __attribute__((packed)) IrrigationPersistedState {
     uint8_t valve_states[4];         // ValveState per valve (CLOSED=0, OPEN=1, UNKNOWN=2)
     uint8_t pending_valve_close;     // 0=no pending close, 1=pending valve close timer
     uint8_t pending_close_valve_id;  // Which valve to close when timer fires
-    uint8_t padding[20];             // Reserved (pad to 32 bytes)
+    uint8_t valve_timer_armed;       // 0=PMU timer not armed yet, 1=armed (PMU will fire it)
+    uint16_t valve_duration_seconds; // Duration the valve was opened for (used to arm timer)
+    uint8_t padding[17];             // Reserved (pad to 32 bytes)
 };
 static_assert(sizeof(IrrigationPersistedState) == 32, "IrrigationPersistedState must be 32 bytes");
 
-constexpr uint8_t IRRIGATION_STATE_VERSION = 5;
+// Bumped to 6: added valve_timer_armed and valve_duration_seconds.
+// Old state from version 5 will be rejected, triggering cold start (closes all valves)
+// which rescues any valve stuck open from a missed timer setup.
+constexpr uint8_t IRRIGATION_STATE_VERSION = 6;
 
 /**
  * @brief Irrigation node mode for valve control
@@ -67,6 +72,7 @@ private:
     bool pending_valve_close_ = false;
     uint8_t pending_close_valve_id_ = 0;
     uint16_t valve_duration_seconds_ = 0;
+    bool valve_timer_armed_ = false;  // True when PMU has accepted setValveTimer
     AddressSavedCallback address_saved_callback_;
 
     /**


### PR DESCRIPTION
## Summary
Scheduled-wake fires from cold boot: opens valve, sets \`pending_valve_close_\`, then takes the normal init path that bypasses VALVE_ACTIVE state. The PMU's RTC Alarm A is never armed, so the valve stays open forever.

## Fix
- Add \`valve_timer_armed_\` flag, persist in PMU state blob (replaces 3 bytes of padding)
- \`onUpdateReceived(false)\` routes to VALVE_ACTIVE if a close is pending but timer not yet armed
- Reset the flag on fresh Scheduled wake and on ValveTimer close
- Bump state version 5→6 to force cold start (calls closeAllValves) on first boot of new firmware — rescues currently stuck-open valves

## Test plan
- [x] V4 build clean
- [ ] Flash; verify boot triggers cold start (valve closes immediately)
- [ ] Add a 1-min schedule, verify VALVE_TIMER_SET event recorded
- [ ] Wait for schedule fire, verify valve opens then closes after duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)