### PR TITLE
fix(dashboard): pass original URI through nginx api proxy

### DIFF
--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -23,9 +23,14 @@ server {
 
     # Proxy API requests to the api service. The hostname is assigned to a
     # variable so nginx resolves it per-request via the resolver above.
+    #
+    # Note: when proxy_pass uses a variable, nginx does not do the normal
+    # location-prefix rewrite — if a URI is specified in the directive, it
+    # replaces the entire original request URI. So we must omit the URI and
+    # let nginx forward the original /api/... path unchanged.
     location /api/ {
         set $upstream_api api;
-        proxy_pass http://$upstream_api:5000/api/;
+        proxy_pass http://$upstream_api:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- Commit ab3e2d4 introduced a variable in nginx `proxy_pass` to re-resolve the api hostname per request, but accidentally disabled nginx's location-prefix rewrite. With a variable + URI in `proxy_pass`, nginx uses the directive's URI **as-is** instead of appending the part after the location prefix.
- As a result every `/api/…` request was arriving at Flask as just `/api/`, hitting the 404 handler and returning `{"error": "Endpoint not found"}` — which is exactly what the mobile dashboard was showing.
- Fix: drop the `/api/` suffix from `proxy_pass` so nginx forwards the original request URI unchanged. Keeps the resolver/variable behavior from ab3e2d4 intact.

## Test plan

- [ ] Deploy via watchtower and hard-reload dashboard on mobile (Firefox Focus) — node list should load instead of "Endpoint not found"
- [ ] Confirm `connected` dot turns green (health check reaches Flask)
- [ ] Sanity-check desktop still works after hard reload
- [ ] Restart the `api` container and confirm the dashboard recovers without needing an nginx restart (the original goal of ab3e2d4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)