### PR TITLE
feat(dashboard): show recent events for all node types

### DIFF
--- a/dashboard/src/components/CurtainControl.tsx
+++ b/dashboard/src/components/CurtainControl.tsx
@@ -1,37 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
-import { controlCurtain, getNodeEvents } from '../api/client';
-import type { NodeEvent } from '../types';
-import { getEventName } from '../types';
-import { REFRESH_INTERVAL_MS } from '../config';
+import { useState } from 'react';
+import { controlCurtain } from '../api/client';
 
 interface CurtainControlProps {
   address: number;
-  deviceId: string;
+  onEventTriggered?: () => void;
 }
 
-function CurtainControl({ address, deviceId }: CurtainControlProps) {
+function CurtainControl({ address, onEventTriggered }: CurtainControlProps) {
   const [sending, setSending] = useState<string | null>(null);
   const [lastAction, setLastAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [events, setEvents] = useState<NodeEvent[]>([]);
-  const [loadingEvents, setLoadingEvents] = useState(true);
-
-  const fetchEvents = useCallback(async () => {
-    try {
-      const response = await getNodeEvents(deviceId, { limit: 20 });
-      setEvents(response.events);
-    } catch {
-      // Silently fail — events are informational
-    } finally {
-      setLoadingEvents(false);
-    }
-  }, [deviceId]);
-
-  useEffect(() => {
-    fetchEvents();
-    const interval = setInterval(fetchEvents, REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchEvents]);
 
   const handleAction = async (action: 'open' | 'close' | 'stop') => {
     setSending(action);
@@ -40,7 +18,7 @@ function CurtainControl({ address, deviceId }: CurtainControlProps) {
       await controlCurtain(address, action);
       setLastAction(action);
       // Refresh events after a short delay to allow the event to propagate
-      setTimeout(fetchEvents, 3000);
+      if (onEventTriggered) setTimeout(onEventTriggered, 3000);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send command');
     } finally {
@@ -48,80 +26,38 @@ function CurtainControl({ address, deviceId }: CurtainControlProps) {
     }
   };
 
-  const formatTime = (timestamp: number): string => {
-    const date = new Date(timestamp * 1000);
-    return date.toLocaleString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-  };
-
   return (
-    <div className="space-y-4">
-      {/* Controls */}
-      <div className="card">
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Curtain Control</h3>
+    <div className="card">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">Curtain Control</h3>
 
-        <div className="flex gap-3">
-          <button
-            onClick={() => handleAction('open')}
-            disabled={sending !== null}
-            className="btn flex-1 bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
-          >
-            {sending === 'open' ? 'Sending...' : 'Open'}
-          </button>
-          <button
-            onClick={() => handleAction('stop')}
-            disabled={sending !== null}
-            className="btn flex-1 bg-amber-500 text-white hover:bg-amber-600 disabled:opacity-50"
-          >
-            {sending === 'stop' ? 'Sending...' : 'Stop'}
-          </button>
-          <button
-            onClick={() => handleAction('close')}
-            disabled={sending !== null}
-            className="btn flex-1 bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
-          >
-            {sending === 'close' ? 'Sending...' : 'Close'}
-          </button>
-        </div>
-
-        {lastAction && !error && (
-          <p className="mt-3 text-sm text-green-600">Curtain {lastAction} command queued.</p>
-        )}
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+      <div className="flex gap-3">
+        <button
+          onClick={() => handleAction('open')}
+          disabled={sending !== null}
+          className="btn flex-1 bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+        >
+          {sending === 'open' ? 'Sending...' : 'Open'}
+        </button>
+        <button
+          onClick={() => handleAction('stop')}
+          disabled={sending !== null}
+          className="btn flex-1 bg-amber-500 text-white hover:bg-amber-600 disabled:opacity-50"
+        >
+          {sending === 'stop' ? 'Sending...' : 'Stop'}
+        </button>
+        <button
+          onClick={() => handleAction('close')}
+          disabled={sending !== null}
+          className="btn flex-1 bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+        >
+          {sending === 'close' ? 'Sending...' : 'Close'}
+        </button>
       </div>
 
-      {/* Event History */}
-      <div className="card">
-        <h4 className="text-sm font-medium text-gray-700 mb-3">Recent Events</h4>
-        {loadingEvents ? (
-          <div className="animate-pulse space-y-2">
-            <div className="h-4 bg-gray-200 rounded w-3/4" />
-            <div className="h-4 bg-gray-200 rounded w-1/2" />
-          </div>
-        ) : events.length === 0 ? (
-          <p className="text-sm text-gray-400">No events recorded yet.</p>
-        ) : (
-          <div className="overflow-y-auto max-h-64">
-            <table className="w-full text-sm">
-              <tbody className="divide-y divide-gray-100">
-                {events.map((event, index) => (
-                  <tr key={index}>
-                    <td className="py-1.5 text-gray-700">{getEventName(event.event_code)}</td>
-                    <td className="py-1.5 text-gray-400 text-right whitespace-nowrap">
-                      {formatTime(event.timestamp)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      {lastAction && !error && (
+        <p className="mt-3 text-sm text-green-600">Curtain {lastAction} command queued.</p>
+      )}
+      {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
     </div>
   );
 }

--- a/dashboard/src/components/IrrigationControl.tsx
+++ b/dashboard/src/components/IrrigationControl.tsx
@@ -7,13 +7,11 @@ import {
   getIrrigationSchedules,
   addIrrigationSchedule,
   deleteIrrigationSchedule,
-  getNodeEvents,
 } from '../api/client';
-import type { NodeEvent, IrrigationSchedule } from '../types';
+import type { IrrigationSchedule } from '../types';
 import { DAY_LABELS } from '../types';
 import { REFRESH_INTERVAL_MS } from '../config';
 import { SchedulesList } from './SchedulesList';
-import { RecentEvents } from './RecentEvents';
 
 type ValveActionState = 'idle' | 'sending' | 'queued' | 'error';
 
@@ -25,6 +23,7 @@ interface ValveState {
 
 interface IrrigationControlProps {
   deviceId: string;
+  onEventTriggered?: () => void;
 }
 
 // Non-linear notches: fine-grained at short durations, coarser for long runs
@@ -50,7 +49,7 @@ function formatDurationShort(minutes: number): string {
   return `${minutes}m`;
 }
 
-function IrrigationControl({ deviceId }: IrrigationControlProps) {
+function IrrigationControl({ deviceId, onEventTriggered }: IrrigationControlProps) {
   // Run-once state
   const [selectedDuration, setSelectedDuration] = useState<Record<number, number>>({
     0: 300,
@@ -80,10 +79,6 @@ function IrrigationControl({ deviceId }: IrrigationControlProps) {
   const [formDays, setFormDays] = useState(127);
   const [savingSchedule, setSavingSchedule] = useState(false);
 
-  // Events state
-  const [events, setEvents] = useState<NodeEvent[]>([]);
-  const [loadingEvents, setLoadingEvents] = useState(true);
-
   const fetchSchedules = useCallback(async () => {
     try {
       const response = await getIrrigationSchedules(deviceId);
@@ -95,26 +90,11 @@ function IrrigationControl({ deviceId }: IrrigationControlProps) {
     }
   }, [deviceId]);
 
-  const fetchEvents = useCallback(async () => {
-    try {
-      const response = await getNodeEvents(deviceId, { limit: 20 });
-      setEvents(response.events);
-    } catch {
-      // Silently fail
-    } finally {
-      setLoadingEvents(false);
-    }
-  }, [deviceId]);
-
   useEffect(() => {
     fetchSchedules();
-    fetchEvents();
-    const interval = setInterval(() => {
-      fetchSchedules();
-      fetchEvents();
-    }, REFRESH_INTERVAL_MS);
+    const interval = setInterval(fetchSchedules, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [fetchSchedules, fetchEvents]);
+  }, [fetchSchedules]);
 
   const handleRun = async (valve: number) => {
     setValveState(valve, { state: 'sending', action: 'run' });
@@ -123,7 +103,7 @@ function IrrigationControl({ deviceId }: IrrigationControlProps) {
       await runValve(deviceId, valve, duration);
       setValveState(valve, { state: 'queued', action: 'run' });
       // Refresh events soon to pick up Valve Open / Valve Timer Set.
-      setTimeout(fetchEvents, 3000);
+      if (onEventTriggered) setTimeout(onEventTriggered, 3000);
       // Return to idle after the Queued checkmark has been visible.
       setTimeout(() => {
         setValveStates((prev) =>
@@ -144,7 +124,7 @@ function IrrigationControl({ deviceId }: IrrigationControlProps) {
     try {
       await stopValve(deviceId, valve);
       setValveState(valve, { state: 'idle' });
-      setTimeout(fetchEvents, 3000);
+      if (onEventTriggered) setTimeout(onEventTriggered, 3000);
     } catch (err) {
       setValveState(valve, {
         state: 'error',
@@ -472,9 +452,6 @@ function IrrigationControl({ deviceId }: IrrigationControlProps) {
           </div>
         </div>
       )}
-
-      {/* Recent Events */}
-      <RecentEvents events={events} loading={loadingEvents} />
     </div>
   );
 }

--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type {
   Node,
+  NodeEvent,
   NodeStatistics,
   SensorReading,
   TimeRange,
@@ -16,7 +17,14 @@ import {
   getBatteryStatus,
   getHealthStatus,
 } from '../types';
-import { getNodeSensorData, getNodeStatistics, deleteNode, rebootNode, setWakeInterval } from '../api/client';
+import {
+  getNodeSensorData,
+  getNodeStatistics,
+  deleteNode,
+  rebootNode,
+  setWakeInterval,
+  getNodeEvents,
+} from '../api/client';
 import { NodeType } from '../types';
 import CurtainControl from './CurtainControl';
 import IrrigationControl from './IrrigationControl';
@@ -28,6 +36,8 @@ import BatteryGauge from './BatteryGauge';
 import SignalStrength from './SignalStrength';
 import HealthStatus from './HealthStatus';
 import BacklogStatus from './BacklogStatus';
+import { RecentEvents } from './RecentEvents';
+import { REFRESH_INTERVAL_MS } from '../config';
 
 interface NodeDetailProps {
   node: Node;
@@ -61,6 +71,8 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
   const [wakeIntervalMinutes, setWakeIntervalMinutes] = useState('1');
   const [settingWakeInterval, setSettingWakeInterval] = useState(false);
   const [wakeIntervalStatus, setWakeIntervalStatus] = useState<string | null>(null);
+  const [events, setEvents] = useState<NodeEvent[]>([]);
+  const [loadingEvents, setLoadingEvents] = useState(true);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const hasSensorData = node.type === NodeType.SENSOR;
@@ -137,6 +149,23 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
       abortControllerRef.current?.abort();
     };
   }, [fetchData]);
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const response = await getNodeEvents(node.device_id, { limit: 20 });
+      setEvents(response.events);
+    } catch {
+      // Silently fail — events are informational
+    } finally {
+      setLoadingEvents(false);
+    }
+  }, [node.device_id]);
+
+  useEffect(() => {
+    fetchEvents();
+    const interval = setInterval(fetchEvents, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchEvents]);
 
   const handleMetadataUpdate = (metadata: NodeMetadata) => {
     onUpdate({
@@ -245,111 +274,112 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-1 flex flex-col gap-4">
           {/* 1. Statistics (sensor nodes only) */}
-          {hasSensorData && (loadingStatistics ? (
-            <div className="card animate-pulse">
-              <div className="h-5 w-24 bg-gray-200 rounded mb-4" />
-              <div className="space-y-3">
-                <div>
-                  <div className="h-3 w-24 bg-gray-200 rounded mb-1" />
-                  <div className="h-6 w-16 bg-gray-200 rounded" />
-                </div>
-                <div className="border-t pt-3">
-                  <div className="h-3 w-20 bg-gray-200 rounded mb-2" />
-                  <div className="grid grid-cols-3 gap-2">
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                  </div>
-                </div>
-                <div className="border-t pt-3">
-                  <div className="h-3 w-16 bg-gray-200 rounded mb-2" />
-                  <div className="grid grid-cols-3 gap-2">
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                    <div>
-                      <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
-                      <div className="h-4 w-12 bg-gray-200 rounded" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : (
-            statistics && (
-              <div className="card">
-                <h3 className="text-lg font-medium text-gray-900 mb-4">Statistics</h3>
-                <dl className="space-y-3">
+          {hasSensorData &&
+            (loadingStatistics ? (
+              <div className="card animate-pulse">
+                <div className="h-5 w-24 bg-gray-200 rounded mb-4" />
+                <div className="space-y-3">
                   <div>
-                    <dt className="text-sm text-gray-500">Total Readings</dt>
-                    <dd className="text-xl font-semibold text-gray-900">
-                      {statistics.total_readings.toLocaleString()}
-                    </dd>
+                    <div className="h-3 w-24 bg-gray-200 rounded mb-1" />
+                    <div className="h-6 w-16 bg-gray-200 rounded" />
                   </div>
                   <div className="border-t pt-3">
-                    <dt className="text-sm text-gray-500 mb-2">Temperature</dt>
-                    <div className="grid grid-cols-3 gap-2 text-sm">
+                    <div className="h-3 w-20 bg-gray-200 rounded mb-2" />
+                    <div className="grid grid-cols-3 gap-2">
                       <div>
-                        <div className="text-gray-400">Min</div>
-                        <div className="font-medium">
-                          {statistics.temperature.min_celsius?.toFixed(1) ?? '-'}C
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                       <div>
-                        <div className="text-gray-400">Avg</div>
-                        <div className="font-medium">
-                          {statistics.temperature.avg_celsius?.toFixed(1) ?? '-'}C
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                       <div>
-                        <div className="text-gray-400">Max</div>
-                        <div className="font-medium">
-                          {statistics.temperature.max_celsius?.toFixed(1) ?? '-'}C
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                     </div>
                   </div>
                   <div className="border-t pt-3">
-                    <dt className="text-sm text-gray-500 mb-2">Humidity</dt>
-                    <div className="grid grid-cols-3 gap-2 text-sm">
+                    <div className="h-3 w-16 bg-gray-200 rounded mb-2" />
+                    <div className="grid grid-cols-3 gap-2">
                       <div>
-                        <div className="text-gray-400">Min</div>
-                        <div className="font-medium">
-                          {statistics.humidity.min_percent?.toFixed(1) ?? '-'}%
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                       <div>
-                        <div className="text-gray-400">Avg</div>
-                        <div className="font-medium">
-                          {statistics.humidity.avg_percent?.toFixed(1) ?? '-'}%
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                       <div>
-                        <div className="text-gray-400">Max</div>
-                        <div className="font-medium">
-                          {statistics.humidity.max_percent?.toFixed(1) ?? '-'}%
-                        </div>
+                        <div className="h-3 w-8 bg-gray-200 rounded mb-1" />
+                        <div className="h-4 w-12 bg-gray-200 rounded" />
                       </div>
                     </div>
                   </div>
-                </dl>
+                </div>
               </div>
-            )
-          ))}
+            ) : (
+              statistics && (
+                <div className="card">
+                  <h3 className="text-lg font-medium text-gray-900 mb-4">Statistics</h3>
+                  <dl className="space-y-3">
+                    <div>
+                      <dt className="text-sm text-gray-500">Total Readings</dt>
+                      <dd className="text-xl font-semibold text-gray-900">
+                        {statistics.total_readings.toLocaleString()}
+                      </dd>
+                    </div>
+                    <div className="border-t pt-3">
+                      <dt className="text-sm text-gray-500 mb-2">Temperature</dt>
+                      <div className="grid grid-cols-3 gap-2 text-sm">
+                        <div>
+                          <div className="text-gray-400">Min</div>
+                          <div className="font-medium">
+                            {statistics.temperature.min_celsius?.toFixed(1) ?? '-'}C
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-400">Avg</div>
+                          <div className="font-medium">
+                            {statistics.temperature.avg_celsius?.toFixed(1) ?? '-'}C
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-400">Max</div>
+                          <div className="font-medium">
+                            {statistics.temperature.max_celsius?.toFixed(1) ?? '-'}C
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="border-t pt-3">
+                      <dt className="text-sm text-gray-500 mb-2">Humidity</dt>
+                      <div className="grid grid-cols-3 gap-2 text-sm">
+                        <div>
+                          <div className="text-gray-400">Min</div>
+                          <div className="font-medium">
+                            {statistics.humidity.min_percent?.toFixed(1) ?? '-'}%
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-400">Avg</div>
+                          <div className="font-medium">
+                            {statistics.humidity.avg_percent?.toFixed(1) ?? '-'}%
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-400">Max</div>
+                          <div className="font-medium">
+                            {statistics.humidity.max_percent?.toFixed(1) ?? '-'}%
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </dl>
+                </div>
+              )
+            ))}
 
           {/* Node Info */}
           <NodeNameEditor
@@ -520,7 +550,9 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
                       </button>
                     </div>
                     {wakeIntervalStatus && (
-                      <p className={`text-xs mt-1 ${wakeIntervalStatus.startsWith('Queued') ? 'text-green-600' : 'text-red-600'}`}>
+                      <p
+                        className={`text-xs mt-1 ${wakeIntervalStatus.startsWith('Queued') ? 'text-green-600' : 'text-red-600'}`}
+                      >
                         {wakeIntervalStatus}
                       </p>
                     )}
@@ -560,11 +592,11 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
         {/* Controls column — renders first on mobile */}
         <div className="lg:col-span-2 space-y-4 order-first lg:order-none">
           {node.type === NodeType.GREENHOUSE && (
-            <CurtainControl address={node.address} deviceId={node.device_id} />
+            <CurtainControl address={node.address} onEventTriggered={fetchEvents} />
           )}
 
           {node.type === NodeType.IRRIGATION && (
-            <IrrigationControl deviceId={node.device_id} />
+            <IrrigationControl deviceId={node.device_id} onEventTriggered={fetchEvents} />
           )}
 
           {hasSensorData && (
@@ -625,6 +657,8 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
               )}
             </div>
           )}
+
+          <RecentEvents events={events} loading={loadingEvents} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Lift event fetching from `IrrigationControl` and `CurtainControl` into `NodeDetail` so **all** node types display the shared `RecentEvents` timeline
- Replace `CurtainControl`'s inline events table with the shared component
- Type-specific controls (valve actions, curtain commands) trigger event refresh via `onEventTriggered` callback

## Test plan
- [ ] Open a **sensor** node detail → Recent Events section appears
- [ ] Open an **irrigation** node → valve controls + Recent Events both visible
- [ ] Open a **greenhouse** node → curtain controls + Recent Events both visible
- [ ] Trigger a valve/curtain action → events refresh after ~3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)