### PR TITLE
fix(greenhouse): pull pending updates after heartbeat response

### DIFF
--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -282,6 +282,13 @@ void GreenhouseMode::onHeartbeatResponse(const HeartbeatResponsePayload *payload
         });
     }
 
+    // Pull any pending updates (actuator commands, wake interval, schedules)
+    if (payload && payload->pending_update_flags != PENDING_FLAG_NONE) {
+        logger.info("Pending update flags: 0x%02X, sending CHECK_UPDATES",
+                    payload->pending_update_flags);
+        sendCheckUpdates();
+    }
+
     updateGreenhouseState();
 }
 


### PR DESCRIPTION
## Summary

- Commit 0d93a71 changed actuator commands from direct RELIABLE send to queued delivery via CHECK_UPDATES, but `GreenhouseMode::onHeartbeatResponse()` never called `sendCheckUpdates()` when pending flags were set
- Curtain open/close/stop commands were queued on the hub but never delivered to the greenhouse node
- Add the same pending-flag check that SensorMode and IrrigationMode already use

## Test plan

- [ ] Flash greenhouse node with updated firmware
- [ ] Send curtain open/close commands from dashboard
- [ ] Verify hub logs show CHECK_UPDATES from 0x0002 followed by UPDATE_AVAILABLE delivery
- [ ] Confirm curtains actually move

🤖 Generated with [Claude Code](https://claude.com/claude-code)