### PR TITLE
feat: unified node events with FRAM persistence

### DIFF
--- a/dashboard/src/components/CurtainControl.tsx
+++ b/dashboard/src/components/CurtainControl.tsx
@@ -1,5 +1,16 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { Zap, ChevronUp, ChevronDown, Square, Check, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
 import { controlCurtain } from '../api/client';
+
+type CurtainAction = 'open' | 'close' | 'stop';
+type CurtainActionState = 'idle' | 'sending' | 'queued' | 'error';
+
+interface ButtonState {
+  state: CurtainActionState;
+  action?: CurtainAction;
+  errorMessage?: string;
+}
 
 interface CurtainControlProps {
   address: number;
@@ -7,57 +18,145 @@ interface CurtainControlProps {
 }
 
 function CurtainControl({ address, onEventTriggered }: CurtainControlProps) {
-  const [sending, setSending] = useState<string | null>(null);
-  const [lastAction, setLastAction] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [buttonState, setButtonState] = useState<ButtonState>({ state: 'idle' });
 
-  const handleAction = async (action: 'open' | 'close' | 'stop') => {
-    setSending(action);
-    setError(null);
+  const dismissError = useCallback(() => {
+    setButtonState({ state: 'idle' });
+  }, []);
+
+  const handleAction = async (action: CurtainAction) => {
+    setButtonState({ state: 'sending', action });
     try {
       await controlCurtain(address, action);
-      setLastAction(action);
-      // Refresh events after a short delay to allow the event to propagate
+      setButtonState({ state: 'queued', action });
       if (onEventTriggered) setTimeout(onEventTriggered, 3000);
+      setTimeout(() => {
+        setButtonState((prev) => (prev.state === 'queued' ? { state: 'idle' } : prev));
+      }, 2000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send command');
-    } finally {
-      setSending(null);
+      setButtonState({
+        state: 'error',
+        action,
+        errorMessage: err instanceof Error ? err.message : 'Failed to send command',
+      });
     }
   };
+
+  const isBusy = buttonState.state === 'sending' || buttonState.state === 'queued';
+  const isSending = (action: CurtainAction) =>
+    buttonState.state === 'sending' && buttonState.action === action;
+  const isQueued = (action: CurtainAction) =>
+    buttonState.state === 'queued' && buttonState.action === action;
+
+  const renderActionButton = (
+    action: CurtainAction,
+    label: string,
+    Icon: typeof ChevronUp,
+    baseClass: string
+  ) => (
+    <motion.button
+      onClick={() => handleAction(action)}
+      disabled={isBusy}
+      className={`relative flex-1 h-11 rounded-xl font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-90 ${baseClass}`}
+      animate={{ scale: isQueued(action) ? [1, 1.03, 1] : 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {isSending(action) ? (
+          <motion.div
+            key="sending"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+            className="flex items-center justify-center gap-2"
+          >
+            <motion.div
+              animate={{ rotate: 360 }}
+              transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+            >
+              <Zap className="w-4 h-4" />
+            </motion.div>
+            <span>Sending...</span>
+          </motion.div>
+        ) : isQueued(action) ? (
+          <motion.div
+            key="queued"
+            initial={{ opacity: 0, scale: 0.85 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.85 }}
+            transition={{ duration: 0.25, type: 'spring' }}
+            className="flex items-center justify-center gap-2"
+          >
+            <Check className="w-5 h-5 stroke-[3]" />
+            <span>Queued</span>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="idle"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+            className="flex items-center justify-center gap-2"
+          >
+            <Icon className="w-4 h-4" />
+            <span>{label}</span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
 
   return (
     <div className="card">
       <h3 className="text-lg font-medium text-gray-900 mb-4">Curtain Control</h3>
 
       <div className="flex gap-3">
-        <button
-          onClick={() => handleAction('open')}
-          disabled={sending !== null}
-          className="btn flex-1 bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
-        >
-          {sending === 'open' ? 'Sending...' : 'Open'}
-        </button>
-        <button
-          onClick={() => handleAction('stop')}
-          disabled={sending !== null}
-          className="btn flex-1 bg-amber-500 text-white hover:bg-amber-600 disabled:opacity-50"
-        >
-          {sending === 'stop' ? 'Sending...' : 'Stop'}
-        </button>
-        <button
-          onClick={() => handleAction('close')}
-          disabled={sending !== null}
-          className="btn flex-1 bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
-        >
-          {sending === 'close' ? 'Sending...' : 'Close'}
-        </button>
+        {renderActionButton(
+          'open',
+          'Open',
+          ChevronUp,
+          'bg-green-600 text-white hover:bg-green-700 active:bg-green-800'
+        )}
+        {renderActionButton(
+          'stop',
+          'Stop',
+          Square,
+          'bg-amber-500 text-white hover:bg-amber-600 active:bg-amber-700'
+        )}
+        {renderActionButton(
+          'close',
+          'Close',
+          ChevronDown,
+          'bg-red-600 text-white hover:bg-red-700 active:bg-red-800'
+        )}
       </div>
 
-      {lastAction && !error && (
-        <p className="mt-3 text-sm text-green-600">Curtain {lastAction} command queued.</p>
-      )}
-      {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+      {/* Persistent error — stays until dismissed */}
+      <AnimatePresence>
+        {buttonState.state === 'error' && buttonState.errorMessage && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="mt-3 bg-red-50 border border-red-200 rounded-xl p-3 flex items-start justify-between gap-3 overflow-hidden"
+          >
+            <div className="flex items-start gap-2 flex-1 min-w-0">
+              <X className="w-4 h-4 text-red-600 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-red-700 break-words">{buttonState.errorMessage}</p>
+            </div>
+            <button
+              onClick={dismissError}
+              className="text-red-400 hover:text-red-600 transition-colors flex-shrink-0"
+              aria-label="Dismiss error"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -22,7 +22,6 @@ import {
   Check,
 } from 'lucide-react';
 import { format, isToday, isYesterday } from 'date-fns';
-import { motion, AnimatePresence } from 'motion/react';
 import { useState } from 'react';
 import type { NodeEvent } from '../types';
 import { getEventName, EventType, EventCode } from '../types';
@@ -247,43 +246,37 @@ export function RecentEvents({ events, loading }: RecentEventsProps) {
               <div className="text-xs font-medium text-gray-500 mb-1.5 px-1">{day}</div>
 
               <div>
-                <AnimatePresence initial={false}>
-                  {dayEvents.map((event, index) => {
-                    const visual = EVENT_VISUALS[event.event_code] ?? DEFAULT_VISUAL;
-                    const Icon = visual.icon;
-                    return (
-                      <motion.div
-                        key={`${event.timestamp}-${event.event_code}-${index}`}
-                        layout
-                        initial={{ opacity: 0, y: -12, scale: 0.97 }}
-                        animate={{ opacity: 1, y: 0, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0.97 }}
-                        transition={{ duration: 0.25, ease: 'easeOut' }}
-                        className="group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
-                      >
-                        <div className="relative flex-shrink-0 mt-px">
-                          <div
-                            className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
-                          >
-                            <Icon className={`w-3 h-3 ${visual.color}`} />
-                          </div>
-                          {index < dayEvents.length - 1 && (
-                            <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
-                          )}
+                {dayEvents.map((event, index) => {
+                  const visual = EVENT_VISUALS[event.event_code] ?? DEFAULT_VISUAL;
+                  const Icon = visual.icon;
+                  return (
+                    <div
+                      key={`${event.timestamp}-${event.event_code}-${index}`}
+                      className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
+                      style={{ animationDelay: `${index * 30}ms` }}
+                    >
+                      <div className="relative flex-shrink-0 mt-px">
+                        <div
+                          className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
+                        >
+                          <Icon className={`w-3 h-3 ${visual.color}`} />
                         </div>
+                        {index < dayEvents.length - 1 && (
+                          <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
+                        )}
+                      </div>
 
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-start justify-between gap-2 mb-px">
-                            <span className="text-sm font-medium text-gray-900">
-                              {getEventName(event.event_code)}
-                            </span>
-                            <CopyableTimestamp timestamp={event.timestamp} />
-                          </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2 mb-px">
+                          <span className="text-sm font-medium text-gray-900">
+                            {getEventName(event.event_code)}
+                          </span>
+                          <CopyableTimestamp timestamp={event.timestamp} />
                         </div>
-                      </motion.div>
-                    );
-                  })}
-                </AnimatePresence>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           ))}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -32,6 +32,15 @@ body {
 .scrollbar-hide::-webkit-scrollbar { display: none; }
 .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 
+/* Recent-events list item fade-in with stagger */
+@keyframes event-fade-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.event-item {
+  animation: event-fade-in 0.2s ease-out both;
+}
+
 /* Plotly hover tooltip styling - semi-opaque background */
 .hoverlayer .hovertext path {
   fill: rgba(255, 255, 255, 0.95) !important;

--- a/pmu-stm32/Core/Inc/persistent_storage.h
+++ b/pmu-stm32/Core/Inc/persistent_storage.h
@@ -1,10 +1,10 @@
 #ifndef PERSISTENT_STORAGE_H
 #define PERSISTENT_STORAGE_H
 
+#include <cstdint>
+
 #include "fram.h"
 #include "pmu_protocol.h"
-
-#include <cstdint>
 
 // Persistent storage layer on top of FRAM.
 // Manages a memory map with magic/version header and typed accessors
@@ -14,7 +14,7 @@
 // allowing the system to fall back to RAM-only behavior.
 class PersistentStorage {
 public:
-    explicit PersistentStorage(FRAM& fram);
+    explicit PersistentStorage(FRAM &fram);
 
     // Check magic number and format version. Formats storage if uninitialised.
     // Returns true if storage is usable (FRAM present and formatted).
@@ -23,60 +23,120 @@ public:
     bool isAvailable() const { return available_; }
 
     // Wake interval
-    bool loadWakeInterval(uint32_t& seconds);
+    bool loadWakeInterval(uint32_t &seconds);
     bool saveWakeInterval(uint32_t seconds);
 
     // Watering schedules — per-entry access (no bulk load needed)
     uint8_t getScheduleCount();
-    bool loadScheduleEntry(uint8_t index, PMU::ScheduleEntry& entry);
-    bool saveScheduleEntry(uint8_t index, const PMU::ScheduleEntry& entry);
+    bool loadScheduleEntry(uint8_t index, PMU::ScheduleEntry &entry);
+    bool saveScheduleEntry(uint8_t index, const PMU::ScheduleEntry &entry);
     bool setScheduleCount(uint8_t count);
 
-    // Opaque node state blob
-    bool loadNodeState(uint8_t* state, uint8_t length);
-    bool saveNodeState(const uint8_t* state, uint8_t length);
+    // Opaque node state blob (legacy — prefer blob slot API below)
+    bool loadNodeState(uint8_t *state, uint8_t length);
+    bool saveNodeState(const uint8_t *state, uint8_t length);
     bool isNodeStateValid();
     bool invalidateNodeState();
 
-    // Wipe all persistent state (schedules, wake interval, node state) and re-initialise
+    // --- Generic blob storage ---
+    // Slots are fixed-capacity FRAM regions identified by slot ID.
+    // The STM32 treats blob data as opaque bytes.
+    static constexpr uint8_t MAX_BLOB_SLOTS = 4;
+    static constexpr uint8_t BLOB_SLOT_NODE_STATE = 0;
+    static constexpr uint8_t BLOB_SLOT_EVENT_LOG = 1;
+
+    // Write a chunk of data into a blob slot at the given offset.
+    bool saveBlobChunk(uint8_t slot, uint16_t offset, const uint8_t *data, uint8_t length);
+
+    // Set the used length of a blob slot (called on first chunk).
+    bool setBlobLength(uint8_t slot, uint16_t length);
+
+    // Get the used length of a blob slot (0 = empty).
+    uint16_t getBlobLength(uint8_t slot);
+
+    // Read a chunk of data from a blob slot at the given offset.
+    // Returns number of bytes actually read.
+    uint8_t loadBlobChunk(uint8_t slot, uint16_t offset, uint8_t *data, uint8_t maxLength);
+
+    // Clear a blob slot (sets used_length to 0).
+    bool clearBlob(uint8_t slot);
+
+    // Wipe all persistent state (schedules, wake interval, node state, blobs) and re-initialise
     // with fresh magic/version. Returns true on success.
     bool factoryReset();
 
 private:
-    FRAM& fram_;
+    FRAM &fram_;
     bool available_;
 
     bool formatStorage();
+    bool initBlobDirectory();
 
     // Memory map — offsets derived from MAX_SCHEDULE_ENTRIES so they
     // adjust automatically if the schedule capacity changes.
     //
-    // Layout:
+    // Layout (legacy region, preserved for backward compat):
     //   [0x0000] Magic (4)
     //   [0x0004] Version (4)
     //   [0x0008] Wake interval (4)
     //   [0x000C] Schedule count (1)
     //   [0x000D] Reserved (3)
     //   [0x0010] Schedule entries (SCHEDULE_ENTRY_SIZE × MAX_SCHEDULE_ENTRIES)
-    //   [...]    Node state (NODE_STATE_SIZE)
+    //   [...]    Node state (NODE_STATE_SIZE) — legacy location, migrated to blob slot 0
     //   [...]    Node state valid flag (4)
-    static constexpr uint16_t OFFSET_MAGIC           = 0x0000;
-    static constexpr uint16_t OFFSET_VERSION          = 0x0004;
-    static constexpr uint16_t OFFSET_WAKE_INTERVAL    = 0x0008;
-    static constexpr uint16_t OFFSET_SCHEDULE_COUNT   = 0x000C;
-    static constexpr uint16_t OFFSET_SCHEDULES        = 0x0010;
-    static constexpr uint16_t OFFSET_NODE_STATE       = OFFSET_SCHEDULES
-        + PMU::SCHEDULE_ENTRY_SIZE * PMU::MAX_SCHEDULE_ENTRIES;
-    static constexpr uint16_t OFFSET_NODE_STATE_FLAG  = OFFSET_NODE_STATE + PMU::NODE_STATE_SIZE;
-    static constexpr uint16_t TOTAL_USED              = OFFSET_NODE_STATE_FLAG + sizeof(uint32_t);
+    //
+    // Blob directory (appended after legacy region):
+    //   [0x006C] Blob magic (2) — 0x424C ("BL")
+    //   [0x006E] Slot count (1)
+    //   [0x006F] Reserved (1)
+    //   [0x0070] Slot descriptors (6 bytes each × MAX_BLOB_SLOTS)
+    //   [0x0088] Slot 0 data: Node State (capacity 48)
+    //   [0x00B8] Slot 1 data: Event Log (capacity 140)
+    static constexpr uint16_t OFFSET_MAGIC = 0x0000;
+    static constexpr uint16_t OFFSET_VERSION = 0x0004;
+    static constexpr uint16_t OFFSET_WAKE_INTERVAL = 0x0008;
+    static constexpr uint16_t OFFSET_SCHEDULE_COUNT = 0x000C;
+    static constexpr uint16_t OFFSET_SCHEDULES = 0x0010;
+    static constexpr uint16_t OFFSET_NODE_STATE =
+        OFFSET_SCHEDULES + PMU::SCHEDULE_ENTRY_SIZE * PMU::MAX_SCHEDULE_ENTRIES;
+    static constexpr uint16_t OFFSET_NODE_STATE_FLAG = OFFSET_NODE_STATE + PMU::NODE_STATE_SIZE;
+    static constexpr uint16_t LEGACY_TOTAL_USED = OFFSET_NODE_STATE_FLAG + sizeof(uint32_t);
+
+    // Blob directory layout
+    static constexpr uint16_t OFFSET_BLOB_DIR = LEGACY_TOTAL_USED;  // 0x006C
+    static constexpr uint16_t BLOB_MAGIC = 0x424C;                  // "BL"
+    static constexpr uint8_t BLOB_DIR_HEADER_SIZE = 4;  // magic(2) + count(1) + reserved(1)
+    static constexpr uint8_t BLOB_SLOT_DESC_SIZE = 6;   // offset(2) + capacity(2) + used_length(2)
+    static constexpr uint16_t OFFSET_BLOB_SLOTS = OFFSET_BLOB_DIR + BLOB_DIR_HEADER_SIZE;
+    static constexpr uint16_t OFFSET_BLOB_DATA_START =
+        OFFSET_BLOB_SLOTS + BLOB_SLOT_DESC_SIZE * MAX_BLOB_SLOTS;  // 0x0088
+
+    // Slot 0: Node State
+    static constexpr uint16_t BLOB_SLOT0_CAPACITY = 48;
+    static constexpr uint16_t BLOB_SLOT0_DATA_OFFSET = OFFSET_BLOB_DATA_START;  // 0x0088
+
+    // Slot 1: Event Log
+    static constexpr uint16_t BLOB_SLOT1_CAPACITY = 140;
+    static constexpr uint16_t BLOB_SLOT1_DATA_OFFSET =
+        BLOB_SLOT0_DATA_OFFSET + BLOB_SLOT0_CAPACITY;  // 0x00B8
+
+    static constexpr uint16_t TOTAL_USED = BLOB_SLOT1_DATA_OFFSET + BLOB_SLOT1_CAPACITY;
     static_assert(TOTAL_USED <= FRAM::CAPACITY, "Persistent storage layout exceeds FRAM capacity");
 
-    static constexpr uint32_t MAGIC = 0x4652414D;   // "FRAM" in ASCII
-    static constexpr uint32_t FORMAT_VERSION = 2;    // Bumped: dynamic schedule layout
+    static constexpr uint32_t MAGIC = 0x4652414D;  // "FRAM" in ASCII
+    static constexpr uint32_t FORMAT_VERSION = 2;  // Bumped: dynamic schedule layout
 
-    uint16_t scheduleEntryOffset(uint8_t index) const {
+    uint16_t scheduleEntryOffset(uint8_t index) const
+    {
         return OFFSET_SCHEDULES + index * PMU::SCHEDULE_ENTRY_SIZE;
+    }
+
+    // Get FRAM offset and capacity for a blob slot
+    bool getBlobSlotInfo(uint8_t slot, uint16_t &dataOffset, uint16_t &capacity) const;
+    uint16_t blobSlotDescOffset(uint8_t slot) const
+    {
+        return OFFSET_BLOB_SLOTS + slot * BLOB_SLOT_DESC_SIZE;
     }
 };
 
-#endif // PERSISTENT_STORAGE_H
+#endif  // PERSISTENT_STORAGE_H

--- a/pmu-stm32/Core/Inc/pmu_protocol.h
+++ b/pmu-stm32/Core/Inc/pmu_protocol.h
@@ -22,7 +22,10 @@ enum class Command : uint8_t {
     ClearToSend = 0x19,    // RP2040 signals ready to receive wake info
     SystemReset = 0x1A,    // Request full system reset (PMU resets itself + RP2040)
     FactoryReset = 0x1B,   // Wipe FRAM persistent storage, then reset
-    SetValveTimer = 0x1C   // Set RTC Alarm A for valve auto-close (3 bytes: duration_lo, duration_hi, valve_id)
+    SetValveTimer =
+        0x1C,  // Set RTC Alarm A for valve auto-close (3 bytes: duration_lo, duration_hi, valve_id)
+    SaveBlob = 0x1D,  // Save chunked data to a FRAM blob slot
+    LoadBlob = 0x1E   // Load data from a FRAM blob slot
 };
 
 // Response codes (STM32 → RP2040)
@@ -34,7 +37,8 @@ enum class Response : uint8_t {
     WakeReason = 0x84,
     Status = 0x85,
     ScheduleComplete = 0x86,  // Scheduled watering complete, power down imminent
-    DateTimeResponse = 0x87   // Response to GetDateTime: valid flag + 7 datetime bytes
+    DateTimeResponse = 0x87,  // Response to GetDateTime: valid flag + 7 datetime bytes
+    BlobData = 0x88           // Response to LoadBlob: chunked blob data
 };
 
 // Error codes
@@ -87,9 +91,10 @@ inline bool operator!(DayOfWeek a)
 constexpr uint8_t START_BYTE = 0xAA;
 constexpr uint8_t END_BYTE = 0x55;
 constexpr uint8_t MAX_SCHEDULE_ENTRIES = 8;
-constexpr uint8_t MAX_MESSAGE_SIZE = 48;     // Increased to accommodate state blob (was 32)
+constexpr uint8_t MAX_MESSAGE_SIZE = 48;  // Increased to accommodate state blob (was 32)
 constexpr uint8_t SCHEDULE_ENTRY_SIZE = 7;
-constexpr uint8_t NODE_STATE_SIZE = 32;  // Opaque state blob stored in PMU RAM
+constexpr uint8_t NODE_STATE_SIZE = 32;      // Opaque state blob stored in PMU RAM
+constexpr uint8_t MAX_BLOB_CHUNK_SIZE = 36;  // Max data bytes per SaveBlob/BlobData message
 
 // Sequence number ranges (for deduplication)
 constexpr uint8_t SEQ_RP2040_MIN = 1;
@@ -165,8 +170,8 @@ public:
 
     // Find the schedule entry closest to triggering.
     // Returns true and populates `out` if found.
-    bool findNextEntry(uint8_t currentDay, uint8_t currentHour,
-                       uint8_t currentMinute, ScheduleEntry &out) const;
+    bool findNextEntry(uint8_t currentDay, uint8_t currentHour, uint8_t currentMinute,
+                       ScheduleEntry &out) const;
 
     // Get count of active entries
     uint8_t getCount() const;
@@ -305,8 +310,8 @@ public:
     }
 
     // Find the next scheduled entry. Returns true and populates `out` if found.
-    bool getNextScheduledEntry(uint8_t currentDay, uint8_t currentHour,
-                               uint8_t currentMinute, ScheduleEntry &out) const;
+    bool getNextScheduledEntry(uint8_t currentDay, uint8_t currentHour, uint8_t currentMinute,
+                               ScheduleEntry &out) const;
 
     // Set callback for valve timer alarm configuration
     void setValveTimerCallback(SetValveTimerCallback callback) { setValveTimer_ = callback; }
@@ -360,6 +365,8 @@ private:
     void handleReadyForSleep();
     void handleGetDateTime();
     void handleSetValveTimer(const uint8_t *data, uint8_t length);
+    void handleSaveBlob(const uint8_t *data, uint8_t length);
+    void handleLoadBlob(const uint8_t *data, uint8_t length);
 
     // Response senders (with sequence number echo)
     void sendAck();

--- a/pmu-stm32/Core/Src/persistent_storage.cpp
+++ b/pmu-stm32/Core/Src/persistent_storage.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-PersistentStorage::PersistentStorage(FRAM& fram) : fram_(fram), available_(false) {}
+PersistentStorage::PersistentStorage(FRAM &fram) : fram_(fram), available_(false) {}
 
 bool PersistentStorage::init()
 {
@@ -13,7 +13,7 @@ bool PersistentStorage::init()
 
     // Read magic number
     uint32_t magic = 0;
-    if (!fram_.read(OFFSET_MAGIC, reinterpret_cast<uint8_t*>(&magic), sizeof(magic))) {
+    if (!fram_.read(OFFSET_MAGIC, reinterpret_cast<uint8_t *>(&magic), sizeof(magic))) {
         available_ = false;
         return false;
     }
@@ -25,7 +25,7 @@ bool PersistentStorage::init()
         }
     } else {
         uint32_t version = 0;
-        if (!fram_.read(OFFSET_VERSION, reinterpret_cast<uint8_t*>(&version), sizeof(version))) {
+        if (!fram_.read(OFFSET_VERSION, reinterpret_cast<uint8_t *>(&version), sizeof(version))) {
             available_ = false;
             return false;
         }
@@ -37,19 +37,26 @@ bool PersistentStorage::init()
         }
     }
 
+    // Initialize blob directory (migrates node state on first run)
+    if (!initBlobDirectory()) {
+        available_ = false;
+        return false;
+    }
+
     available_ = true;
     return true;
 }
 
 bool PersistentStorage::formatStorage()
 {
-    // Zero out the used area
-    uint16_t usedSize = OFFSET_NODE_STATE_FLAG + sizeof(uint32_t);
+    // Zero out the entire used area (including blob region)
+    uint16_t usedSize = TOTAL_USED;
     // Write in chunks to avoid large stack allocation
     uint8_t zeros[64] = {};
     for (uint16_t offset = 0; offset < usedSize; offset += sizeof(zeros)) {
         uint16_t chunk = usedSize - offset;
-        if (chunk > sizeof(zeros)) chunk = sizeof(zeros);
+        if (chunk > sizeof(zeros))
+            chunk = sizeof(zeros);
         if (!fram_.write(offset, zeros, chunk)) {
             return false;
         }
@@ -58,16 +65,16 @@ bool PersistentStorage::formatStorage()
     // Write magic and version
     uint32_t magic = MAGIC;
     uint32_t version = FORMAT_VERSION;
-    if (!fram_.write(OFFSET_MAGIC, reinterpret_cast<uint8_t*>(&magic), sizeof(magic))) {
+    if (!fram_.write(OFFSET_MAGIC, reinterpret_cast<uint8_t *>(&magic), sizeof(magic))) {
         return false;
     }
-    if (!fram_.write(OFFSET_VERSION, reinterpret_cast<uint8_t*>(&version), sizeof(version))) {
+    if (!fram_.write(OFFSET_VERSION, reinterpret_cast<uint8_t *>(&version), sizeof(version))) {
         return false;
     }
 
     // Default wake interval: 60 seconds (matches Protocol constructor default)
     uint32_t defaultInterval = 60;
-    if (!fram_.write(OFFSET_WAKE_INTERVAL, reinterpret_cast<uint8_t*>(&defaultInterval),
+    if (!fram_.write(OFFSET_WAKE_INTERVAL, reinterpret_cast<uint8_t *>(&defaultInterval),
                      sizeof(defaultInterval))) {
         return false;
     }
@@ -77,16 +84,18 @@ bool PersistentStorage::formatStorage()
 
 // --- Wake interval ---
 
-bool PersistentStorage::loadWakeInterval(uint32_t& seconds)
+bool PersistentStorage::loadWakeInterval(uint32_t &seconds)
 {
-    if (!available_) return false;
-    return fram_.read(OFFSET_WAKE_INTERVAL, reinterpret_cast<uint8_t*>(&seconds), sizeof(seconds));
+    if (!available_)
+        return false;
+    return fram_.read(OFFSET_WAKE_INTERVAL, reinterpret_cast<uint8_t *>(&seconds), sizeof(seconds));
 }
 
 bool PersistentStorage::saveWakeInterval(uint32_t seconds)
 {
-    if (!available_) return false;
-    return fram_.write(OFFSET_WAKE_INTERVAL, reinterpret_cast<const uint8_t*>(&seconds),
+    if (!available_)
+        return false;
+    return fram_.write(OFFSET_WAKE_INTERVAL, reinterpret_cast<const uint8_t *>(&seconds),
                        sizeof(seconds));
 }
 
@@ -94,7 +103,8 @@ bool PersistentStorage::saveWakeInterval(uint32_t seconds)
 
 uint8_t PersistentStorage::getScheduleCount()
 {
-    if (!available_) return 0;
+    if (!available_)
+        return 0;
 
     uint8_t count = 0;
     if (!fram_.read(OFFSET_SCHEDULE_COUNT, &count, 1)) {
@@ -108,14 +118,17 @@ uint8_t PersistentStorage::getScheduleCount()
 
 bool PersistentStorage::setScheduleCount(uint8_t count)
 {
-    if (!available_) return false;
-    if (count > PMU::MAX_SCHEDULE_ENTRIES) return false;
+    if (!available_)
+        return false;
+    if (count > PMU::MAX_SCHEDULE_ENTRIES)
+        return false;
     return fram_.write(OFFSET_SCHEDULE_COUNT, &count, 1);
 }
 
-bool PersistentStorage::loadScheduleEntry(uint8_t index, PMU::ScheduleEntry& entry)
+bool PersistentStorage::loadScheduleEntry(uint8_t index, PMU::ScheduleEntry &entry)
 {
-    if (!available_ || index >= PMU::MAX_SCHEDULE_ENTRIES) return false;
+    if (!available_ || index >= PMU::MAX_SCHEDULE_ENTRIES)
+        return false;
 
     uint8_t raw[PMU::SCHEDULE_ENTRY_SIZE];
     if (!fram_.read(scheduleEntryOffset(index), raw, PMU::SCHEDULE_ENTRY_SIZE)) {
@@ -131,9 +144,10 @@ bool PersistentStorage::loadScheduleEntry(uint8_t index, PMU::ScheduleEntry& ent
     return true;
 }
 
-bool PersistentStorage::saveScheduleEntry(uint8_t index, const PMU::ScheduleEntry& entry)
+bool PersistentStorage::saveScheduleEntry(uint8_t index, const PMU::ScheduleEntry &entry)
 {
-    if (!available_ || index >= PMU::MAX_SCHEDULE_ENTRIES) return false;
+    if (!available_ || index >= PMU::MAX_SCHEDULE_ENTRIES)
+        return false;
 
     uint8_t raw[PMU::SCHEDULE_ENTRY_SIZE];
     raw[0] = entry.hour;
@@ -149,33 +163,38 @@ bool PersistentStorage::saveScheduleEntry(uint8_t index, const PMU::ScheduleEntr
 
 // --- Node state ---
 
-bool PersistentStorage::loadNodeState(uint8_t* state, uint8_t length)
+bool PersistentStorage::loadNodeState(uint8_t *state, uint8_t length)
 {
-    if (!available_) return false;
-    if (length > PMU::NODE_STATE_SIZE) return false;
+    if (!available_)
+        return false;
+    if (length > PMU::NODE_STATE_SIZE)
+        return false;
     return fram_.read(OFFSET_NODE_STATE, state, length);
 }
 
-bool PersistentStorage::saveNodeState(const uint8_t* state, uint8_t length)
+bool PersistentStorage::saveNodeState(const uint8_t *state, uint8_t length)
 {
-    if (!available_) return false;
-    if (length > PMU::NODE_STATE_SIZE) return false;
+    if (!available_)
+        return false;
+    if (length > PMU::NODE_STATE_SIZE)
+        return false;
 
     if (!fram_.write(OFFSET_NODE_STATE, state, length)) {
         return false;
     }
 
     uint32_t validFlag = 1;
-    return fram_.write(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t*>(&validFlag),
+    return fram_.write(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t *>(&validFlag),
                        sizeof(validFlag));
 }
 
 bool PersistentStorage::isNodeStateValid()
 {
-    if (!available_) return false;
+    if (!available_)
+        return false;
 
     uint32_t flag = 0;
-    if (!fram_.read(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t*>(&flag), sizeof(flag))) {
+    if (!fram_.read(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t *>(&flag), sizeof(flag))) {
         return false;
     }
     return flag == 1;
@@ -183,14 +202,160 @@ bool PersistentStorage::isNodeStateValid()
 
 bool PersistentStorage::factoryReset()
 {
-    if (!available_) return false;
+    if (!available_)
+        return false;
     return formatStorage();
 }
 
 bool PersistentStorage::invalidateNodeState()
 {
-    if (!available_) return false;
+    if (!available_)
+        return false;
 
     uint32_t flag = 0;
-    return fram_.write(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t*>(&flag), sizeof(flag));
+    return fram_.write(OFFSET_NODE_STATE_FLAG, reinterpret_cast<uint8_t *>(&flag), sizeof(flag));
+}
+
+// --- Blob storage ---
+
+bool PersistentStorage::initBlobDirectory()
+{
+    // Check if blob directory is already initialized
+    uint16_t magic = 0;
+    if (!fram_.read(OFFSET_BLOB_DIR, reinterpret_cast<uint8_t *>(&magic), sizeof(magic))) {
+        return false;
+    }
+
+    if (magic == BLOB_MAGIC) {
+        return true;  // Already initialized
+    }
+
+    // First time: write blob directory header
+    magic = BLOB_MAGIC;
+    if (!fram_.write(OFFSET_BLOB_DIR, reinterpret_cast<const uint8_t *>(&magic), sizeof(magic))) {
+        return false;
+    }
+    uint8_t slot_count = 2;
+    if (!fram_.write(OFFSET_BLOB_DIR + 2, &slot_count, 1)) {
+        return false;
+    }
+    uint8_t reserved = 0;
+    if (!fram_.write(OFFSET_BLOB_DIR + 3, &reserved, 1)) {
+        return false;
+    }
+
+    // Write slot 0 descriptor (Node State)
+    uint16_t desc0[3] = {BLOB_SLOT0_DATA_OFFSET, BLOB_SLOT0_CAPACITY, 0};
+    if (!fram_.write(blobSlotDescOffset(0), reinterpret_cast<uint8_t *>(desc0),
+                     BLOB_SLOT_DESC_SIZE)) {
+        return false;
+    }
+
+    // Write slot 1 descriptor (Event Log)
+    uint16_t desc1[3] = {BLOB_SLOT1_DATA_OFFSET, BLOB_SLOT1_CAPACITY, 0};
+    if (!fram_.write(blobSlotDescOffset(1), reinterpret_cast<uint8_t *>(desc1),
+                     BLOB_SLOT_DESC_SIZE)) {
+        return false;
+    }
+
+    // Migrate existing node state from legacy location to blob slot 0
+    if (isNodeStateValid()) {
+        uint8_t state[PMU::NODE_STATE_SIZE];
+        if (fram_.read(OFFSET_NODE_STATE, state, PMU::NODE_STATE_SIZE)) {
+            // Write to blob slot 0 data region
+            if (fram_.write(BLOB_SLOT0_DATA_OFFSET, state, PMU::NODE_STATE_SIZE)) {
+                // Update slot 0 used_length
+                uint16_t used = PMU::NODE_STATE_SIZE;
+                fram_.write(blobSlotDescOffset(0) + 4, reinterpret_cast<uint8_t *>(&used),
+                            sizeof(used));
+            }
+        }
+    }
+
+    return true;
+}
+
+bool PersistentStorage::getBlobSlotInfo(uint8_t slot, uint16_t &dataOffset,
+                                        uint16_t &capacity) const
+{
+    if (slot >= MAX_BLOB_SLOTS)
+        return false;
+
+    uint16_t desc[3];
+    if (!fram_.read(blobSlotDescOffset(slot), reinterpret_cast<uint8_t *>(desc),
+                    BLOB_SLOT_DESC_SIZE)) {
+        return false;
+    }
+    dataOffset = desc[0];
+    capacity = desc[1];
+    return true;
+}
+
+bool PersistentStorage::saveBlobChunk(uint8_t slot, uint16_t offset, const uint8_t *data,
+                                      uint8_t length)
+{
+    if (!available_ || slot >= MAX_BLOB_SLOTS)
+        return false;
+
+    uint16_t dataOffset, capacity;
+    if (!getBlobSlotInfo(slot, dataOffset, capacity))
+        return false;
+    if (offset + length > capacity)
+        return false;
+
+    return fram_.write(dataOffset + offset, data, length);
+}
+
+bool PersistentStorage::setBlobLength(uint8_t slot, uint16_t length)
+{
+    if (!available_ || slot >= MAX_BLOB_SLOTS)
+        return false;
+
+    uint16_t dataOffset, capacity;
+    if (!getBlobSlotInfo(slot, dataOffset, capacity))
+        return false;
+    if (length > capacity)
+        return false;
+
+    return fram_.write(blobSlotDescOffset(slot) + 4, reinterpret_cast<uint8_t *>(&length),
+                       sizeof(length));
+}
+
+uint16_t PersistentStorage::getBlobLength(uint8_t slot)
+{
+    if (!available_ || slot >= MAX_BLOB_SLOTS)
+        return 0;
+
+    uint16_t used = 0;
+    fram_.read(blobSlotDescOffset(slot) + 4, reinterpret_cast<uint8_t *>(&used), sizeof(used));
+    return used;
+}
+
+uint8_t PersistentStorage::loadBlobChunk(uint8_t slot, uint16_t offset, uint8_t *data,
+                                         uint8_t maxLength)
+{
+    if (!available_ || slot >= MAX_BLOB_SLOTS)
+        return 0;
+
+    uint16_t dataOffset, capacity;
+    if (!getBlobSlotInfo(slot, dataOffset, capacity))
+        return 0;
+
+    uint16_t used = getBlobLength(slot);
+    if (offset >= used)
+        return 0;
+
+    uint8_t toRead = maxLength;
+    if (offset + toRead > used) {
+        toRead = static_cast<uint8_t>(used - offset);
+    }
+
+    if (!fram_.read(dataOffset + offset, data, toRead))
+        return 0;
+    return toRead;
+}
+
+bool PersistentStorage::clearBlob(uint8_t slot)
+{
+    return setBlobLength(slot, 0);
 }

--- a/pmu-stm32/Core/Src/pmu_protocol.cpp
+++ b/pmu-stm32/Core/Src/pmu_protocol.cpp
@@ -125,7 +125,8 @@ WateringSchedule::WateringSchedule() : storage_(nullptr) {}
 
 ErrorCode WateringSchedule::addEntry(const ScheduleEntry &entry)
 {
-    if (!storage_) return ErrorCode::InvalidParam;
+    if (!storage_)
+        return ErrorCode::InvalidParam;
 
     if (!entry.isValid()) {
         return ErrorCode::InvalidParam;
@@ -153,7 +154,8 @@ ErrorCode WateringSchedule::addEntry(const ScheduleEntry &entry)
 
 ErrorCode WateringSchedule::removeEntry(uint8_t index)
 {
-    if (!storage_) return ErrorCode::InvalidParam;
+    if (!storage_)
+        return ErrorCode::InvalidParam;
 
     uint8_t count = getCount();
     if (index >= count) {
@@ -186,18 +188,21 @@ void WateringSchedule::clear()
 
 bool WateringSchedule::getEntry(uint8_t index, ScheduleEntry &out) const
 {
-    if (!storage_) return false;
+    if (!storage_)
+        return false;
 
     uint8_t count = getCount();
-    if (index >= count) return false;
+    if (index >= count)
+        return false;
 
     return storage_->loadScheduleEntry(index, out);
 }
 
-bool WateringSchedule::findNextEntry(uint8_t currentDay, uint8_t currentHour,
-                                     uint8_t currentMinute, ScheduleEntry &out) const
+bool WateringSchedule::findNextEntry(uint8_t currentDay, uint8_t currentHour, uint8_t currentMinute,
+                                     ScheduleEntry &out) const
 {
-    if (!storage_) return false;
+    if (!storage_)
+        return false;
 
     uint8_t count = getCount();
     bool found = false;
@@ -205,8 +210,10 @@ bool WateringSchedule::findNextEntry(uint8_t currentDay, uint8_t currentHour,
 
     for (uint8_t i = 0; i < count; i++) {
         ScheduleEntry entry;
-        if (!storage_->loadScheduleEntry(i, entry)) continue;
-        if (!entry.enabled) continue;
+        if (!storage_->loadScheduleEntry(i, entry))
+            continue;
+        if (!entry.enabled)
+            continue;
 
         uint32_t minutes = entry.minutesUntil(currentDay, currentHour, currentMinute);
         if (minutes < minMinutes) {
@@ -221,20 +228,24 @@ bool WateringSchedule::findNextEntry(uint8_t currentDay, uint8_t currentHour,
 
 uint8_t WateringSchedule::getCount() const
 {
-    if (!storage_) return 0;
+    if (!storage_)
+        return 0;
     return storage_->getScheduleCount();
 }
 
 bool WateringSchedule::hasOverlap(const ScheduleEntry &entry, uint8_t excludeIndex) const
 {
-    if (!storage_) return false;
+    if (!storage_)
+        return false;
 
     uint8_t count = getCount();
     for (uint8_t i = 0; i < count; i++) {
-        if (i == excludeIndex) continue;
+        if (i == excludeIndex)
+            continue;
 
         ScheduleEntry existing;
-        if (!storage_->loadScheduleEntry(i, existing)) continue;
+        if (!storage_->loadScheduleEntry(i, existing))
+            continue;
 
         if (entry.overlapsWith(existing)) {
             return true;
@@ -619,6 +630,20 @@ void Protocol::processReceivedByte(uint8_t byte)
                     sendAck();
                 }
                 break;
+            case Command::SaveBlob:
+                if (!isDuplicate) {
+                    handleSaveBlob(data, dataLen);
+                } else {
+                    sendAck();
+                }
+                break;
+            case Command::LoadBlob:
+                if (!isDuplicate) {
+                    handleLoadBlob(data, dataLen);
+                } else {
+                    sendAck();
+                }
+                break;
             default:
                 sendNack(ErrorCode::InvalidParam);
                 break;
@@ -676,8 +701,8 @@ void Protocol::sendScheduleComplete()
     sendMessage();
 }
 
-bool Protocol::getNextScheduledEntry(uint8_t currentDay, uint8_t currentHour,
-                                     uint8_t currentMinute, ScheduleEntry &out) const
+bool Protocol::getNextScheduledEntry(uint8_t currentDay, uint8_t currentHour, uint8_t currentMinute,
+                                     ScheduleEntry &out) const
 {
     return schedule_.findNextEntry(currentDay, currentHour, currentMinute, out);
 }
@@ -690,7 +715,8 @@ void Protocol::setStorage(PersistentStorage *storage)
 
 void Protocol::loadFromStorage()
 {
-    if (!storage_ || !storage_->isAvailable()) return;
+    if (!storage_ || !storage_->isAvailable())
+        return;
 
     // Load wake interval
     uint32_t interval = 0;
@@ -940,6 +966,118 @@ void Protocol::handleSetValveTimer(const uint8_t *data, uint8_t length)
 
     if (setValveTimer_) {
         setValveTimer_(durationSeconds, valveId);
+    }
+}
+
+void Protocol::handleSaveBlob(const uint8_t *data, uint8_t length)
+{
+    // Payload: {slot:1, total_length:2, offset:2, chunk_length:1, data[0-36]}
+    if (length < 6) {
+        sendNack(ErrorCode::InvalidParam);
+        return;
+    }
+
+    uint8_t slot = data[0];
+    uint16_t totalLength = data[1] | (data[2] << 8);
+    uint16_t offset = data[3] | (data[4] << 8);
+    uint8_t chunkLength = data[5];
+
+    if (chunkLength > length - 6) {
+        sendNack(ErrorCode::InvalidParam);
+        return;
+    }
+
+    if (!storage_) {
+        sendNack(ErrorCode::InvalidParam);
+        return;
+    }
+
+    // Clear operation
+    if (totalLength == 0) {
+        if (storage_->clearBlob(slot)) {
+            sendAck();
+        } else {
+            sendNack(ErrorCode::InvalidParam);
+        }
+        return;
+    }
+
+    // Set used_length on first chunk
+    if (offset == 0) {
+        if (!storage_->setBlobLength(slot, totalLength)) {
+            sendNack(ErrorCode::InvalidParam);
+            return;
+        }
+    }
+
+    // Write chunk data
+    if (chunkLength > 0) {
+        if (!storage_->saveBlobChunk(slot, offset, data + 6, chunkLength)) {
+            sendNack(ErrorCode::InvalidParam);
+            return;
+        }
+    }
+
+    sendAck();
+}
+
+void Protocol::handleLoadBlob(const uint8_t *data, uint8_t length)
+{
+    // Payload: {slot:1}
+    if (length < 1) {
+        sendNack(ErrorCode::InvalidParam);
+        return;
+    }
+
+    uint8_t slot = data[0];
+
+    if (!storage_) {
+        sendNack(ErrorCode::InvalidParam);
+        return;
+    }
+
+    // ACK the command first
+    sendAck();
+
+    uint16_t totalLength = storage_->getBlobLength(slot);
+
+    // Send chunked BlobData responses
+    uint16_t offset = 0;
+    do {
+        uint8_t chunkSize = MAX_BLOB_CHUNK_SIZE;
+        if (offset + chunkSize > totalLength) {
+            chunkSize = static_cast<uint8_t>(totalLength - offset);
+        }
+
+        // Read chunk from FRAM
+        uint8_t chunkData[MAX_BLOB_CHUNK_SIZE];
+        uint8_t bytesRead = 0;
+        if (chunkSize > 0) {
+            bytesRead = storage_->loadBlobChunk(slot, offset, chunkData, chunkSize);
+        }
+
+        // Build BlobData response: {slot:1, total_length:2, offset:2, chunk_length:1, data[]}
+        builder_.startMessage(getNextSeqNum(), static_cast<uint8_t>(Response::BlobData));
+        builder_.addByte(slot);
+        builder_.addUint16(totalLength);
+        builder_.addUint16(offset);
+        builder_.addByte(bytesRead);
+        for (uint8_t i = 0; i < bytesRead; i++) {
+            builder_.addByte(chunkData[i]);
+        }
+        sendMessage();
+
+        offset += bytesRead;
+    } while (offset < totalLength);
+
+    // If totalLength was 0, we still need to send one empty BlobData response
+    if (totalLength == 0) {
+        builder_.startMessage(getNextSeqNum(), static_cast<uint8_t>(Response::BlobData));
+        builder_.addByte(slot);
+        builder_.addUint16(0);
+        builder_.addUint16(0);
+        builder_.addByte(0);
+        sendMessage();
     }
 }
 

--- a/src/hal/pmu_protocol.cpp
+++ b/src/hal/pmu_protocol.cpp
@@ -275,6 +275,9 @@ void Protocol::processReceivedByte(uint8_t byte)
             case Response::DateTimeResponse:
                 handleDateTimeResponse(data, dataLen);
                 break;
+            case Response::BlobData:
+                handleBlobData(data, dataLen);
+                break;
             default:
                 // Unknown response, ignore
                 break;
@@ -417,6 +420,11 @@ void Protocol::onScheduleEntry(ScheduleEntryCallback callback)
 void Protocol::onDateTime(DateTimeCallback callback)
 {
     pendingDateTimeCallback_ = callback;
+}
+
+void Protocol::onBlobData(BlobDataCallback callback)
+{
+    blobDataCallback_ = callback;
 }
 
 // Response handlers
@@ -566,6 +574,27 @@ void Protocol::handleDateTimeResponse(const uint8_t *data, uint8_t length)
         auto callback = pendingDateTimeCallback_;
         pendingDateTimeCallback_ = nullptr;
         callback(valid, datetime);
+    }
+}
+
+void Protocol::handleBlobData(const uint8_t *data, uint8_t length)
+{
+    // Expected format: {slot:1, total_length:2, offset:2, chunk_length:1, data[0-36]}
+    if (length < 6) {
+        return;
+    }
+
+    uint8_t slot = data[0];
+    uint16_t totalLength = data[1] | (data[2] << 8);
+    uint16_t offset = data[3] | (data[4] << 8);
+    uint8_t chunkLength = data[5];
+
+    if (chunkLength > length - 6) {
+        chunkLength = length - 6;
+    }
+
+    if (blobDataCallback_) {
+        blobDataCallback_(slot, totalLength, offset, chunkLength, data + 6);
     }
 }
 

--- a/src/hal/pmu_protocol.h
+++ b/src/hal/pmu_protocol.h
@@ -22,7 +22,9 @@ enum class Command : uint8_t {
     SystemReset = 0x1A,    // Request full system reset (PMU resets itself + RP2040)
     FactoryReset = 0x1B,   // Wipe FRAM persistent storage, then reset
     SetValveTimer =
-        0x1C  // Set RTC Alarm A for valve auto-close (3 bytes: duration_lo, duration_hi, valve_id)
+        0x1C,  // Set RTC Alarm A for valve auto-close (3 bytes: duration_lo, duration_hi, valve_id)
+    SaveBlob = 0x1D,  // Save chunked data to a FRAM blob slot
+    LoadBlob = 0x1E   // Load data from a FRAM blob slot
 };
 
 // Response codes (STM32 → RP2040)
@@ -34,7 +36,8 @@ enum class Response : uint8_t {
     WakeReason = 0x84,
     Status = 0x85,
     ScheduleComplete = 0x86,
-    DateTimeResponse = 0x87  // Response to GetDateTime: valid flag + 7 datetime bytes
+    DateTimeResponse = 0x87,  // Response to GetDateTime: valid flag + 7 datetime bytes
+    BlobData = 0x88           // Response to LoadBlob: chunked blob data
 };
 
 // Error codes
@@ -88,7 +91,12 @@ constexpr uint8_t START_BYTE = 0xAA;
 constexpr uint8_t END_BYTE = 0x55;
 constexpr uint8_t MAX_MESSAGE_SIZE = 64;
 constexpr uint8_t SCHEDULE_ENTRY_SIZE = 7;
-constexpr uint8_t NODE_STATE_SIZE = 32;  // Opaque state blob stored in PMU RAM
+constexpr uint8_t NODE_STATE_SIZE = 32;      // Opaque state blob stored in PMU RAM
+constexpr uint8_t MAX_BLOB_CHUNK_SIZE = 36;  // Max data bytes per SaveBlob/BlobData message
+
+// Blob slot IDs
+constexpr uint8_t BLOB_SLOT_NODE_STATE = 0;
+constexpr uint8_t BLOB_SLOT_EVENT_LOG = 1;
 
 // Sequence number ranges (for deduplication)
 constexpr uint8_t SEQ_RP2040_MIN = 1;
@@ -224,6 +232,10 @@ using WakeIntervalCallback = std::function<void(uint32_t seconds)>;
 using ScheduleEntryCallback = std::function<void(const ScheduleEntry &entry)>;
 using DateTimeCallback = std::function<void(bool valid, const DateTime &datetime)>;
 
+// Callback for blob data chunks from LoadBlob response
+using BlobDataCallback = std::function<void(uint8_t slot, uint16_t totalLength, uint16_t offset,
+                                            uint8_t chunkLength, const uint8_t *data)>;
+
 // Callback for ACK with sequence number
 using AckCallback = std::function<void(uint8_t seqNum, bool success, ErrorCode error)>;
 
@@ -262,6 +274,7 @@ public:
     void onWakeInterval(WakeIntervalCallback callback);
     void onScheduleEntry(ScheduleEntryCallback callback);
     void onDateTime(DateTimeCallback callback);
+    void onBlobData(BlobDataCallback callback);
 
     // Get next sequence number for legacy API
     uint8_t getNextSequenceNumber();
@@ -287,6 +300,9 @@ private:
     // Pending datetime callback (for GetDateTime response)
     DateTimeCallback pendingDateTimeCallback_;
 
+    // Blob data callback (for LoadBlob responses)
+    BlobDataCallback blobDataCallback_;
+
     // Response handlers
     void handleAck(uint8_t seqNum);
     void handleNack(uint8_t seqNum, const uint8_t *data, uint8_t length);
@@ -295,6 +311,7 @@ private:
     void handleWakeNotification(const uint8_t *data, uint8_t length);
     void handleScheduleComplete();
     void handleDateTimeResponse(const uint8_t *data, uint8_t length);
+    void handleBlobData(const uint8_t *data, uint8_t length);
 
     // Helper to send built message
     void sendMessage();

--- a/src/hal/pmu_reliability.cpp
+++ b/src/hal/pmu_reliability.cpp
@@ -343,6 +343,97 @@ bool ReliablePmuClient::setValveTimer(uint16_t durationSeconds, uint8_t valveId,
 }
 
 // ============================================================================
+// Blob storage
+// ============================================================================
+
+bool ReliablePmuClient::saveBlob(uint8_t slot, const uint8_t *data, uint16_t length,
+                                 CommandCallback callback)
+{
+    // Clear operation
+    if (length == 0) {
+        // Payload: {slot:1, total_length:2, offset:2, chunk_length:1}
+        uint8_t clearData[6];
+        clearData[0] = slot;
+        clearData[1] = 0;
+        clearData[2] = 0;  // total_length = 0
+        clearData[3] = 0;
+        clearData[4] = 0;  // offset = 0
+        clearData[5] = 0;  // chunk_length = 0
+        return queueCommand(Command::SaveBlob, clearData, 6, callback);
+    }
+
+    // Send data in chunks
+    uint16_t offset = 0;
+    while (offset < length) {
+        uint8_t chunkSize = MAX_BLOB_CHUNK_SIZE;
+        if (offset + chunkSize > length) {
+            chunkSize = static_cast<uint8_t>(length - offset);
+        }
+
+        // Build payload: {slot:1, total_length:2, offset:2, chunk_length:1, data[]}
+        uint8_t payload[6 + MAX_BLOB_CHUNK_SIZE];
+        payload[0] = slot;
+        payload[1] = length & 0xFF;
+        payload[2] = (length >> 8) & 0xFF;
+        payload[3] = offset & 0xFF;
+        payload[4] = (offset >> 8) & 0xFF;
+        payload[5] = chunkSize;
+        std::memcpy(payload + 6, data + offset, chunkSize);
+
+        // Only the last chunk gets the user callback
+        bool isLast = (offset + chunkSize >= length);
+        CommandCallback chunkCallback = isLast ? callback : nullptr;
+
+        if (!queueCommand(Command::SaveBlob, payload, static_cast<uint8_t>(6 + chunkSize),
+                          chunkCallback)) {
+            return false;
+        }
+
+        offset += chunkSize;
+    }
+
+    return true;
+}
+
+bool ReliablePmuClient::loadBlob(uint8_t slot, uint8_t *buffer, uint16_t bufferSize,
+                                 BlobLoadCallback callback)
+{
+    // Register a BlobData callback to accumulate chunks
+    client_->getProtocol().onBlobData(
+        [buffer, bufferSize, callback](uint8_t slot, uint16_t totalLength, uint16_t offset,
+                                       uint8_t chunkLength, const uint8_t *data) {
+            // Copy chunk into caller's buffer
+            if (buffer && chunkLength > 0 && offset + chunkLength <= bufferSize) {
+                std::memcpy(buffer + offset, data, chunkLength);
+            }
+
+            // Check if this is the last chunk (or empty blob)
+            bool isComplete = (totalLength == 0) || (offset + chunkLength >= totalLength);
+            if (isComplete && callback) {
+                uint16_t actualLength = totalLength;
+                if (actualLength > bufferSize) {
+                    actualLength = bufferSize;
+                }
+                callback(true, actualLength);
+            }
+        });
+
+    // Send LoadBlob command: {slot:1}
+    return queueCommand(Command::LoadBlob, &slot, 1, [callback](bool success, ErrorCode error) {
+        // ACK received — BlobData responses will follow
+        // If NACK, signal failure
+        if (!success && callback) {
+            callback(false, 0);
+        }
+    });
+}
+
+bool ReliablePmuClient::clearBlob(uint8_t slot, CommandCallback callback)
+{
+    return saveBlob(slot, nullptr, 0, callback);
+}
+
+// ============================================================================
 // Event callbacks
 // ============================================================================
 

--- a/src/hal/pmu_reliability.h
+++ b/src/hal/pmu_reliability.h
@@ -196,6 +196,39 @@ public:
                        CommandCallback callback = nullptr);
 
     /**
+     * @brief Save an opaque blob to a FRAM slot
+     * @param slot Blob slot ID (e.g. BLOB_SLOT_NODE_STATE, BLOB_SLOT_EVENT_LOG)
+     * @param data Pointer to blob data (may be nullptr if length is 0)
+     * @param length Total blob length in bytes
+     * @param callback Called when all chunks are ACK'd (optional)
+     * @return true if command(s) queued successfully
+     *
+     * Data is automatically chunked into MAX_BLOB_CHUNK_SIZE-byte messages.
+     * Passing length=0 clears the slot.
+     */
+    bool saveBlob(uint8_t slot, const uint8_t *data, uint16_t length,
+                  CommandCallback callback = nullptr);
+
+    /**
+     * @brief Load a blob from a FRAM slot
+     * @param slot Blob slot ID
+     * @param buffer Output buffer to receive blob data
+     * @param bufferSize Size of output buffer
+     * @param callback Called when load completes: (bool success, uint16_t length)
+     * @return true if command queued successfully
+     */
+    using BlobLoadCallback = std::function<void(bool success, uint16_t length)>;
+    bool loadBlob(uint8_t slot, uint8_t *buffer, uint16_t bufferSize, BlobLoadCallback callback);
+
+    /**
+     * @brief Clear a FRAM blob slot
+     * @param slot Blob slot ID
+     * @param callback Called when command completes (optional)
+     * @return true if command queued successfully
+     */
+    bool clearBlob(uint8_t slot, CommandCallback callback = nullptr);
+
+    /**
      * @brief Get access to the underlying PmuClient
      * Useful for accessing the protocol directly for operations
      * not covered by the reliable client.

--- a/src/modes/application_mode.cpp
+++ b/src/modes/application_mode.cpp
@@ -330,8 +330,25 @@ void ApplicationMode::initEventLogTransmitter()
 void ApplicationMode::onBeforeSleep()
 {
     event_log_.record(EventType::SLEEP_ENTER, 0, 0);
+
+    // Try LoRa TX of pending events
+    bool tx_ok = true;
     if (event_log_transmitter_ && event_log_.hasPending()) {
-        event_log_transmitter_->transmitIfPending(event_log_);
+        tx_ok = event_log_transmitter_->transmitIfPending(event_log_);
+    }
+
+    // If events remain after TX (failed or partial), persist to FRAM for next cycle
+    if (event_log_.hasPending() && reliable_pmu_) {
+        uint8_t blob_buffer[140];
+        uint16_t blob_len = event_log_.serializeToBlob(blob_buffer, sizeof(blob_buffer));
+        if (blob_len > 0) {
+            logger.info("Persisting %u events to FRAM (%u bytes)", event_log_.pendingCount(),
+                        blob_len);
+            reliable_pmu_->saveBlob(PMU::BLOB_SLOT_EVENT_LOG, blob_buffer, blob_len);
+        }
+    } else if (!event_log_.hasPending() && reliable_pmu_) {
+        // TX succeeded — clear any persisted events from previous cycle
+        reliable_pmu_->clearBlob(PMU::BLOB_SLOT_EVENT_LOG);
     }
 }
 

--- a/src/modes/application_mode.cpp
+++ b/src/modes/application_mode.cpp
@@ -23,6 +23,13 @@ extern void processIncomingMessage(uint8_t *rx_buffer, int rx_len, ReliableMesse
 
 void ApplicationMode::run()
 {
+    // Record boot event — watchdog_caused_reboot() is only valid before watchdog_enable()
+    if (watchdog_caused_reboot()) {
+        event_log_.record(EventType::BOOT_WATCHDOG, 1, 0);
+    } else {
+        event_log_.record(EventType::BOOT_COLD, 0, 0);
+    }
+
     // Initialize RTC for all nodes
     rtc_init();
     logger.debug("RTC initialized");
@@ -322,6 +329,7 @@ void ApplicationMode::initEventLogTransmitter()
 
 void ApplicationMode::onBeforeSleep()
 {
+    event_log_.record(EventType::SLEEP_ENTER, 0, 0);
     if (event_log_transmitter_ && event_log_.hasPending()) {
         event_log_transmitter_->transmitIfPending(event_log_);
     }

--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -1,5 +1,7 @@
 #include "greenhouse_mode.h"
 
+#include <cstring>
+
 #include "pico/unique_id.h"
 
 #include "hardware/watchdog.h"
@@ -208,6 +210,38 @@ void GreenhouseMode::onLoop()
     updateGreenhouseState();
 }
 
+void GreenhouseMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
+                                          uint8_t hub_sequence)
+{
+    UpdateType update_type = static_cast<UpdateType>(payload->update_type);
+
+    switch (update_type) {
+        case UpdateType::ACTUATOR_COMMAND: {
+            const uint8_t *data = payload->payload_data;
+            ActuatorPayload actuator;
+            actuator.actuator_type = data[0];
+            actuator.command = data[1];
+            actuator.param_length = data[2];
+            memset(actuator.params, 0, sizeof(actuator.params));
+            if (actuator.param_length > 0 && actuator.param_length <= sizeof(actuator.params)) {
+                memcpy(actuator.params, &data[3], actuator.param_length);
+            }
+
+            logger.info("  ACTUATOR_COMMAND: type=%u, cmd=%u, params=%u", actuator.actuator_type,
+                        actuator.command, actuator.param_length);
+
+            onActuatorCommand(&actuator);
+            onUpdateApplied(hub_sequence);
+            break;
+        }
+
+        default:
+            logger.error("Unknown update type %d", payload->update_type);
+            onUpdateFailed();
+            break;
+    }
+}
+
 void GreenhouseMode::onActuatorCommand(const ActuatorPayload *payload)
 {
     if (!payload) {
@@ -282,8 +316,12 @@ void GreenhouseMode::onHeartbeatResponse(const HeartbeatResponsePayload *payload
         });
     }
 
-    // Pull any pending updates (actuator commands, wake interval, schedules)
-    if (payload && payload->pending_update_flags != PENDING_FLAG_NONE) {
+    // Pull any pending data updates (actuator commands, wake interval, schedules).
+    // Only CHECK_UPDATES for flags that carry data — REREGISTER, REBOOT, and
+    // FACTORY_RESET are handled by their own protocol flows.
+    constexpr uint8_t DATA_FLAGS =
+        PENDING_FLAG_SCHEDULE | PENDING_FLAG_WAKE_INTERVAL | PENDING_FLAG_ACTUATOR;
+    if (payload && (payload->pending_update_flags & DATA_FLAGS)) {
         logger.info("Pending update flags: 0x%02X, sending CHECK_UPDATES",
                     payload->pending_update_flags);
         sendCheckUpdates();

--- a/src/modes/greenhouse_mode.h
+++ b/src/modes/greenhouse_mode.h
@@ -29,6 +29,7 @@ protected:
     void onStart() override;
     void onLoop() override;
     void onActuatorCommand(const ActuatorPayload *payload) override;
+    void onModeSpecificUpdate(const UpdateAvailablePayload *payload, uint8_t hub_sequence) override;
     void onHeartbeatResponse(const HeartbeatResponsePayload *payload) override;
     void onRebootRequested() override;
     void onFactoryResetRequested() override;

--- a/src/modes/hub_mode.cpp
+++ b/src/modes/hub_mode.cpp
@@ -830,8 +830,15 @@ void HubMode::handleHeartbeat(uint16_t source_addr, const HeartbeatPayload *payl
         return;
     }
 
-    // Compute pending update flags for this node
+    // Compute pending update flags for this node.
+    // Also check the node's assigned address (via device_id lookup) because the node
+    // may be heartbeating from a stale or broadcast address while commands are queued
+    // against its registered address.
     uint8_t pending_flags = hub_router_->getPendingUpdateFlags(source_addr);
+    uint16_t assigned_addr = address_manager_->getDeviceAddress(payload->device_id);
+    if (assigned_addr != 0 && assigned_addr != source_addr) {
+        pending_flags |= hub_router_->getPendingUpdateFlags(assigned_addr);
+    }
 
     // Set REREGISTER flag if the node is unknown or device_id doesn't match
     const NodeInfo *node = address_manager_->getNodeInfo(source_addr);

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -88,6 +88,20 @@ void IrrigationMode::onStart()
         // Register PMU with base class for generic update handling
         setReliablePmu(reliable_pmu_);
 
+        // Load any events that failed to transmit in the previous cycle
+        {
+            static uint8_t event_blob_buffer[140];
+            reliable_pmu_->loadBlob(
+                PMU::BLOB_SLOT_EVENT_LOG, event_blob_buffer, sizeof(event_blob_buffer),
+                [this](bool success, uint16_t length) {
+                    if (success && length > 0) {
+                        event_log_.deserializeFromBlob(event_blob_buffer, length);
+                        pmu_logger.info("Loaded %u persisted events from FRAM",
+                                        event_log_.pendingCount());
+                    }
+                });
+        }
+
         // Set up PMU callback handlers
         reliable_pmu_->onWake([this](PMU::WakeReason reason, const PMU::ScheduleEntry *entry,
                                      bool state_valid, const uint8_t *state) {
@@ -551,7 +565,8 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                 if (success || error == PMU::ErrorCode::InvalidIndex) {
                     // Treat removing a non-existent schedule as success (idempotent)
                     if (!success) {
-                        logger.info("  Schedule index %d already empty - treating as removed", index);
+                        logger.info("  Schedule index %d already empty - treating as removed",
+                                    index);
                     } else {
                         logger.info("  Schedule removed successfully");
                     }

--- a/src/modes/irrigation_mode.h
+++ b/src/modes/irrigation_mode.h
@@ -17,17 +17,17 @@
  * On cold start (battery disconnect), state_valid=false.
  */
 struct __attribute__((packed)) IrrigationPersistedState {
-    uint8_t version;                 // Format version
-    uint8_t board_version;           // Board hardware version (3=V3, 4=V4)
-    uint8_t next_seq_num;            // LoRa sequence number
-    uint8_t update_sequence;         // Current update pull sequence number
-    uint16_t assigned_address;       // Node address (survives warm reboot)
-    uint8_t valve_states[4];         // ValveState per valve (CLOSED=0, OPEN=1, UNKNOWN=2)
-    uint8_t pending_valve_close;     // 0=no pending close, 1=pending valve close timer
-    uint8_t pending_close_valve_id;  // Which valve to close when timer fires
-    uint8_t valve_timer_armed;       // 0=PMU timer not armed yet, 1=armed (PMU will fire it)
-    uint16_t valve_duration_seconds; // Duration the valve was opened for (used to arm timer)
-    uint8_t padding[17];             // Reserved (pad to 32 bytes)
+    uint8_t version;                  // Format version
+    uint8_t board_version;            // Board hardware version (3=V3, 4=V4)
+    uint8_t next_seq_num;             // LoRa sequence number
+    uint8_t update_sequence;          // Current update pull sequence number
+    uint16_t assigned_address;        // Node address (survives warm reboot)
+    uint8_t valve_states[4];          // ValveState per valve (CLOSED=0, OPEN=1, UNKNOWN=2)
+    uint8_t pending_valve_close;      // 0=no pending close, 1=pending valve close timer
+    uint8_t pending_close_valve_id;   // Which valve to close when timer fires
+    uint8_t valve_timer_armed;        // 0=PMU timer not armed yet, 1=armed (PMU will fire it)
+    uint16_t valve_duration_seconds;  // Duration the valve was opened for (used to arm timer)
+    uint8_t padding[17];              // Reserved (pad to 32 bytes)
 };
 static_assert(sizeof(IrrigationPersistedState) == 32, "IrrigationPersistedState must be 32 bytes");
 

--- a/src/modes/sensor_mode.cpp
+++ b/src/modes/sensor_mode.cpp
@@ -176,6 +176,9 @@ void SensorMode::onStart()
     if (pmu_ok && pmu_manager_->getReliablePmu()) {
         // Register PMU with base class for generic update handling
         setReliablePmu(pmu_manager_->getReliablePmu());
+
+        // Load any events that failed to transmit in the previous cycle
+        pmu_manager_->loadPersistedEventLog(event_log_);
     }
 
     if (!pmu_ok) {

--- a/src/modes/sensor_mode.cpp
+++ b/src/modes/sensor_mode.cpp
@@ -195,6 +195,7 @@ void SensorMode::onStateChange(SensorState state)
             if (rtc_running()) {
                 sensor_state_.reportTimeSyncComplete();
             } else {
+                event_log_.record(EventType::TIME_SYNC_TIMEOUT, 1, 0);
                 sensor_state_.reportSyncTimeout();
             }
         });
@@ -656,7 +657,9 @@ void SensorMode::transmitBacklog()
     if (!transmitter_->transmit(
             records, valid_records_count,
             [this, total_records_scanned, start_index](bool success) {
-                if (success && flash_buffer_) {
+                if (!success) {
+                    event_log_.record(EventType::TX_BATCH_FAIL, 2, 0);
+                } else if (flash_buffer_) {
                     // Mark each record's transmission_status in flash (NOR-friendly single-byte
                     // write)
                     for (uint32_t i = 0; i < total_records_scanned; i++) {
@@ -685,6 +688,7 @@ void SensorMode::transmitBacklog()
             },
             start_index)) {
         logger.warn("Batch transmission failed to initiate");
+        event_log_.record(EventType::TX_BATCH_FAIL, 2, 0);
         sensor_state_.reportTransmitComplete();
     }
 }
@@ -932,6 +936,7 @@ void SensorMode::attemptRegistration()
         sensor_state_.expectResponse();
     } else {
         logger.error("Failed to send registration request");
+        event_log_.record(EventType::REGISTRATION_FAIL, 2, 0);
         // Failed to send - go to sleep and retry next cycle
         sensor_state_.reportRegistrationTimeout();
     }

--- a/src/modes/sensor_mode.h
+++ b/src/modes/sensor_mode.h
@@ -135,7 +135,6 @@ private:
     // Batch transmission
     std::unique_ptr<BatchTransmitter> transmitter_;
 
-
     // Fallback storage for direct transmit when flash unavailable
     SensorDataRecord current_reading_ = {};
 

--- a/src/util/event_log.h
+++ b/src/util/event_log.h
@@ -103,6 +103,94 @@ public:
     uint32_t timeRefUnix() const { return time_ref_unix_; }
     uint32_t timeRefUptime() const { return time_ref_uptime_ms_; }
 
+    /**
+     * @brief Load previously-persisted records into the ring buffer as pending
+     *
+     * Used on wake to restore events that failed to transmit in the previous cycle.
+     * Records are inserted at the current write position and become pending for TX.
+     *
+     * @param records Array of EventRecords to load
+     * @param count Number of records
+     * @param time_ref_uptime Uptime reference from when records were created
+     * @param time_ref_unix Unix timestamp reference from when records were created
+     */
+    void loadPersisted(const EventRecord *records, uint8_t count, uint32_t time_ref_uptime,
+                       uint32_t time_ref_unix)
+    {
+        // Set time reference from persisted data (will be overwritten when RTC syncs)
+        if (time_ref_unix > 0) {
+            time_ref_uptime_ms_ = time_ref_uptime;
+            time_ref_unix_ = time_ref_unix;
+        }
+
+        for (uint8_t i = 0; i < count && count_ < N; i++) {
+            records_[write_index_] = records[i];
+            write_index_ = (write_index_ + 1) % N;
+            count_++;
+        }
+    }
+
+    /**
+     * @brief Serialize pending events into a blob buffer
+     *
+     * Format: {time_ref_unix:4, time_ref_uptime:4, record_count:1, records[]}
+     *
+     * @param buffer Output buffer
+     * @param max_length Maximum buffer size
+     * @return Number of bytes written (0 if nothing pending or buffer too small)
+     */
+    uint16_t serializeToBlob(uint8_t *buffer, uint16_t max_length) const
+    {
+        if (!hasPending() || max_length < 9) {
+            return 0;
+        }
+
+        // Header: time refs + count
+        uint32_t unix_ts = time_ref_unix_;
+        uint32_t uptime = time_ref_uptime_ms_;
+        memcpy(buffer, &unix_ts, 4);
+        memcpy(buffer + 4, &uptime, 4);
+
+        uint8_t max_records = static_cast<uint8_t>((max_length - 9) / sizeof(EventRecord));
+        uint8_t to_write = (count_ < max_records) ? count_ : max_records;
+        buffer[8] = to_write;
+
+        // Records
+        for (uint8_t i = 0; i < to_write; i++) {
+            memcpy(buffer + 9 + i * sizeof(EventRecord), &records_[(read_index_ + i) % N],
+                   sizeof(EventRecord));
+        }
+
+        return 9 + to_write * sizeof(EventRecord);
+    }
+
+    /**
+     * @brief Deserialize a blob and load records into this event log
+     *
+     * @param data Blob data in the format written by serializeToBlob
+     * @param length Length of blob data
+     */
+    void deserializeFromBlob(const uint8_t *data, uint16_t length)
+    {
+        if (length < 9) {
+            return;
+        }
+
+        uint32_t unix_ts;
+        uint32_t uptime;
+        memcpy(&unix_ts, data, 4);
+        memcpy(&uptime, data + 4, 4);
+
+        uint8_t record_count = data[8];
+        uint16_t expected = 9 + record_count * sizeof(EventRecord);
+        if (expected > length) {
+            record_count = static_cast<uint8_t>((length - 9) / sizeof(EventRecord));
+        }
+
+        const EventRecord *records = reinterpret_cast<const EventRecord *>(data + 9);
+        loadPersisted(records, record_count, uptime, unix_ts);
+    }
+
 private:
     EventRecord records_[N] = {};
     uint8_t write_index_ = 0;

--- a/src/util/sensor_pmu_manager.cpp
+++ b/src/util/sensor_pmu_manager.cpp
@@ -334,3 +334,22 @@ bool SensorPmuManager::unpackState(const SensorPersistedState *persisted)
 
     return true;
 }
+
+void SensorPmuManager::loadPersistedEventLog(EventLog<64> &log)
+{
+    if (!pmu_available_ || !reliable_pmu_) {
+        return;
+    }
+
+    // Static buffer for blob data (max 140 bytes for event log slot)
+    static uint8_t event_blob_buffer[140];
+
+    reliable_pmu_->loadBlob(PMU::BLOB_SLOT_EVENT_LOG, event_blob_buffer, sizeof(event_blob_buffer),
+                            [&log](bool success, uint16_t length) {
+                                if (success && length > 0) {
+                                    log.deserializeFromBlob(event_blob_buffer, length);
+                                    pmu_logger.info("Loaded %u persisted events from FRAM",
+                                                    log.pendingCount());
+                                }
+                            });
+}

--- a/src/util/sensor_pmu_manager.h
+++ b/src/util/sensor_pmu_manager.h
@@ -6,6 +6,7 @@
 
 #include "../hal/pmu_client.h"
 #include "../hal/pmu_reliability.h"
+#include "event_log.h"
 #include "task_queue.h"
 
 class ReliableMessenger;
@@ -157,6 +158,16 @@ public:
      * @brief Set consecutive TX failure count
      */
     void setConsecutiveTxFailures(uint8_t count) { consecutive_tx_failures_ = count; }
+
+    /**
+     * @brief Load persisted event log from FRAM into the given EventLog
+     *
+     * Call after PMU initialization completes. Loads events that failed
+     * to transmit in the previous cycle so they can be retried.
+     *
+     * @param log Event log to populate with persisted records
+     */
+    void loadPersistedEventLog(EventLog<64> &log);
 
     /**
      * @brief Check if PMU hardware is available


### PR DESCRIPTION
## Summary

- **Dashboard**: Show recent events for all node types, replace Framer Motion animation with cross-browser CSS animation
- **Firmware**: Emit missing event log entries (boot, sleep, registration/TX/sync failures)
- **PMU protocol**: Add generic blob storage (SaveBlob/LoadBlob) for FRAM-backed persistence
- **Event log persistence**: On LoRa TX failure before sleep, events are saved to FRAM and retried next wake cycle

## Details

### Events audit
Audited all 24 defined EventTypes — found 8 that were defined but never emitted. Added emissions for 6 (BOOT_COLD, BOOT_WATCHDOG, SLEEP_ENTER, REGISTRATION_FAIL, TIME_SYNC_TIMEOUT, TX_BATCH_FAIL). Skipped SENSOR_READ_OK (too noisy) and EVENT_MOTOR_ERROR (no detection path exists).

### Generic blob storage
Adds a reusable blob storage mechanism to the PMU protocol. FRAM slots are fixed-capacity regions identified by slot ID. Currently slot 1 is used for event log persistence. The mechanism supports chunked transfers (36 bytes/message) for payloads larger than the 42-byte UART message limit.

### FRAM persistence strategy
TX-failure safety net only — no FRAM writes on the happy path. Events live in the RAM ring buffer during the wake cycle. If LoRa TX fails before sleep, remaining events are serialized to FRAM. On next wake, they're loaded back and retransmitted alongside new events.

## Test plan
- [ ] Build all RP2040 variants (`/bramble-build ALL`)
- [ ] Build STM32 PMU firmware
- [ ] Deploy to sensor node, verify events appear in dashboard
- [ ] Verify FRAM persistence: power-cycle during TX, confirm events appear after next successful cycle
- [ ] Verify no regression on existing node state persistence (ReadyForSleep/WakeNotification unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)