### PR TITLE
feat: greenhouse sensor support and unified node events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ else()
             main.cpp
             src/modes/greenhouse_mode.cpp
             src/hal/curtain_controller.cpp
+            src/hal/cht832x.cpp
             src/util/greenhouse_state_machine.cpp
             ${COMMON_SOURCES}
         )

--- a/dashboard/src/components/NodeCard.tsx
+++ b/dashboard/src/components/NodeCard.tsx
@@ -48,7 +48,7 @@ function NodeCard({ node, zone, onClick }: NodeCardProps) {
     }
   }, [node.device_id, node.online, node.type]);
 
-  const hasSparkline = node.type === NodeType.SENSOR && sparklineData.length >= 2;
+  const hasSparkline = (node.type === NodeType.SENSOR || node.type === NodeType.GREENHOUSE) && sparklineData.length >= 2;
 
   const getNodeIcon = (type: string) => {
     switch (type) {

--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -75,7 +75,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
   const [loadingEvents, setLoadingEvents] = useState(true);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  const hasSensorData = node.type === NodeType.SENSOR;
+  const hasSensorData = node.type === NodeType.SENSOR || node.type === NodeType.GREENHOUSE;
 
   const fetchData = useCallback(async () => {
     if (!hasSensorData) {

--- a/main.cpp
+++ b/main.cpp
@@ -128,7 +128,7 @@ inline VariantInfo getVariantInfo()
 #elif HARDWARE_CONTROLLER
     return {NODE_TYPE_CONTROLLER, CAP_CONTROLLER | CAP_SCHEDULING, "Controller"};
 #elif HARDWARE_GREENHOUSE
-    return {NODE_TYPE_HYBRID, CAP_VALVE_CONTROL | CAP_TEMPERATURE | CAP_HUMIDITY, "Greenhouse Node"};
+    return {NODE_TYPE_ACTUATOR, CAP_VALVE_CONTROL | CAP_TEMPERATURE | CAP_HUMIDITY, "Greenhouse Node"};
 #else
     return {NODE_TYPE_SENSOR, 0, "Generic Node"};
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -128,7 +128,7 @@ inline VariantInfo getVariantInfo()
 #elif HARDWARE_CONTROLLER
     return {NODE_TYPE_CONTROLLER, CAP_CONTROLLER | CAP_SCHEDULING, "Controller"};
 #elif HARDWARE_GREENHOUSE
-    return {NODE_TYPE_ACTUATOR, CAP_VALVE_CONTROL, "Greenhouse Node"};
+    return {NODE_TYPE_HYBRID, CAP_VALVE_CONTROL | CAP_TEMPERATURE | CAP_HUMIDITY, "Greenhouse Node"};
 #else
     return {NODE_TYPE_SENSOR, 0, "Generic Node"};
 #endif

--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -116,6 +116,26 @@ void GreenhouseMode::onStart()
         logger.warn("PMU client not available - running without RTC backup");
     }
 
+    // Try to detect CHT832X temperature/humidity sensor on I2C
+    sensor_ = std::make_unique<CHT832X>(Board::SENSOR_I2C_PORT, Board::PIN_I2C_SDA,
+                                        Board::PIN_I2C_SCL);
+    if (sensor_->init()) {
+        sensor_available_ = true;
+        logger.info("CHT832X sensor detected — enabling temperature/humidity sensing");
+
+        BatchTransmitter::Config tx_config = {.max_batches_per_cycle = 1,
+                                              .hub_address = HUB_ADDRESS};
+        transmitter_ = std::make_unique<BatchTransmitter>(messenger_, tx_config);
+
+        constexpr uint32_t SENSOR_READ_INTERVAL_MS = 60000;  // 60 seconds
+        task_manager_.addTask(
+            [this](uint32_t time) { readAndTransmitSensorData(time); },
+            SENSOR_READ_INTERVAL_MS, "Sensor read+transmit");
+    } else {
+        logger.info("No CHT832X sensor detected — running as actuator only");
+        sensor_.reset();
+    }
+
     // Orange blinking while waiting for RTC sync
     led_pattern_ = std::make_unique<BlinkingPattern>(led_, 255, 165, 0, 250, 250);
     // Green short blink when operational
@@ -127,7 +147,8 @@ void GreenhouseMode::onStart()
     uint32_t uptime = 0;
     uint8_t battery_level = 255;  // 255 = external/mains power
     uint8_t signal_strength = 0;
-    uint8_t active_sensors = CAP_VALVE_CONTROL;
+    uint8_t active_sensors = CAP_VALVE_CONTROL |
+                                         (sensor_available_ ? (CAP_TEMPERATURE | CAP_HUMIDITY) : 0);
     uint8_t error_flags = 0;
     messenger_.sendHeartbeat(HUB_ADDRESS, uptime, battery_level, signal_strength, active_sensors,
                              error_flags, 0, device_id);
@@ -139,7 +160,8 @@ void GreenhouseMode::onStart()
             uint8_t battery_level = 255;  // Mains powered
             uint8_t signal_strength = 0;
             uint8_t error_flags = 0;
-            uint8_t active_sensors = CAP_VALVE_CONTROL;
+            uint8_t active_sensors = CAP_VALVE_CONTROL |
+                                         (sensor_available_ ? (CAP_TEMPERATURE | CAP_HUMIDITY) : 0);
 
             if (curtain_controller_.isMotorRunning()) {
                 logger.info("Heartbeat: curtain %s, position ~%.0f%%",
@@ -368,6 +390,50 @@ void GreenhouseMode::onFactoryResetRequested()
         logger.warn("PMU not available - performing RP2040-only watchdog reboot");
     }
     watchdog_reboot(0, 0, 0);
+}
+
+void GreenhouseMode::readAndTransmitSensorData(uint32_t /* current_time */)
+{
+    if (!sensor_ || !transmitter_) {
+        return;
+    }
+
+    CHT832X::Reading reading = sensor_->read();
+    if (!reading.valid) {
+        logger.error("Sensor read failed");
+        return;
+    }
+
+    uint32_t unix_timestamp = getUnixTimestamp();
+    if (unix_timestamp == 0) {
+        logger.warn("No RTC time — skipping sensor transmit");
+        return;
+    }
+
+    int16_t temp_fixed = static_cast<int16_t>(reading.temperature * 100.0f);
+    uint16_t hum_fixed = static_cast<uint16_t>(reading.humidity * 100.0f);
+
+    logger.info("Sensor: %.2fC, %.1f%%RH (ts=%lu)", reading.temperature, reading.humidity,
+                unix_timestamp);
+
+    current_reading_ = {.timestamp = unix_timestamp,
+                        .temperature = temp_fixed,
+                        .humidity = hum_fixed,
+                        .flags = 0,
+                        .transmission_status = RECORD_NOT_TRANSMITTED,
+                        .crc16 = 0};
+
+    transmitter_->resetCycleCounter();
+    if (!transmitter_->transmit(&current_reading_, 1, [](bool success) {
+            Logger log("GREEN");
+            if (success) {
+                log.info("Sensor data transmitted successfully");
+            } else {
+                log.warn("Sensor data transmit failed");
+            }
+        })) {
+        logger.error("Failed to initiate sensor transmit");
+    }
 }
 
 void GreenhouseMode::updateGreenhouseState()

--- a/src/modes/greenhouse_mode.h
+++ b/src/modes/greenhouse_mode.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <memory>
+
 #include "../config/curtain_config.h"
+#include "../hal/cht832x.h"
 #include "../hal/curtain_controller.h"
 #include "../hal/pmu_client.h"
+#include "../lora/batch_transmitter.h"
+#include "../storage/sensor_data_record.h"
 #include "../util/greenhouse_state_machine.h"
 #include "application_mode.h"
 
@@ -20,7 +25,14 @@ private:
     bool pmu_available_;
     GreenhouseStateMachine greenhouse_state_;
 
+    // Optional temperature/humidity sensor (auto-detected on I2C at startup)
+    std::unique_ptr<CHT832X> sensor_;
+    std::unique_ptr<BatchTransmitter> transmitter_;
+    SensorDataRecord current_reading_ = {};
+    bool sensor_available_ = false;
+
     void updateGreenhouseState();
+    void readAndTransmitSensorData(uint32_t current_time);
 
 public:
     using ApplicationMode::ApplicationMode;


### PR DESCRIPTION
## Summary
- Add auto-detected CHT832X temperature/humidity sensing to greenhouse nodes (reads every 60s, transmits via LoRa)
- Fix greenhouse node type classification so hub correctly identifies it as GREENHOUSE (not IRRIGATION)
- Show sensor data and sparklines for GREENHOUSE nodes in dashboard
- Deliver actuator commands to greenhouse node with curtain button animations
- Persist event log to FRAM when LoRa TX fails before sleep
- Add RP2040 blob protocol client and EventLog persistence helpers
- Add generic blob storage to FRAM (SaveBlob/LoadBlob protocol)
- Emit missing event log entries for boot, sleep, and failure paths

## Test plan
- [x] Greenhouse node detects CHT832X sensor on I2C at startup
- [x] Sensor data (temperature/humidity) transmitted to hub every 60s
- [x] Dashboard shows greenhouse node as GREENHOUSE type (not IRRIGATION)
- [x] Curtain open/close/stop commands delivered and executed
- [ ] Dashboard displays sensor data and sparkline for greenhouse nodes
- [ ] Verify event log persistence across power cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)