### PR TITLE
feat(dashboard): polish compact sensor cards with hover interactions

### DIFF
--- a/dashboard/src/components/CompactSensorPanel.tsx
+++ b/dashboard/src/components/CompactSensorPanel.tsx
@@ -1,16 +1,49 @@
-import { TrendingUp, TrendingDown } from 'lucide-react';
 import type { SensorReading, NodeStatistics } from '../types';
 import Sparkline from './Sparkline';
 
 type SensorDataKey = 'temperature_celsius' | 'humidity_percent';
+
+type Trend = 'Steady' | 'Increasing' | 'Decreasing' | 'Fluctuating';
+
+function computeTrend(readings: SensorReading[], dataKey: SensorDataKey): Trend | null {
+  if (readings.length < 3) return null;
+  const sorted = [...readings].sort((a, b) => a.timestamp - b.timestamp);
+  const values = sorted.map((r) => r[dataKey]);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+
+  // "Steady" threshold — small range relative to mean
+  // For temp/humidity, ~0.5 absolute or ~1% relative counts as flat
+  const isSmallRange = range < 0.5 || (mean !== 0 && range / Math.abs(mean) < 0.01);
+  if (isSmallRange) return 'Steady';
+
+  // Linear fit: slope via least squares
+  const n = values.length;
+  const xs = values.map((_, i) => i);
+  const xMean = (n - 1) / 2;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (xs[i] - xMean) * (values[i] - mean);
+    den += (xs[i] - xMean) ** 2;
+  }
+  const slope = den === 0 ? 0 : num / den;
+  const netChange = slope * (n - 1);
+
+  // If the net linear change accounts for >50% of the observed range, it's trending
+  if (Math.abs(netChange) > range * 0.5) {
+    return netChange > 0 ? 'Increasing' : 'Decreasing';
+  }
+  return 'Fluctuating';
+}
 
 interface CompactSensorCardProps {
   label: string;
   unit: string;
   dataKey: SensorDataKey;
   readings: SensorReading[];
-  min: number | null;
-  max: number | null;
   color: string;
   bgClassName: string;
   borderClassName: string;
@@ -22,8 +55,6 @@ function CompactSensorCard({
   unit,
   dataKey,
   readings,
-  min,
-  max,
   color,
   bgClassName,
   borderClassName,
@@ -31,48 +62,37 @@ function CompactSensorCard({
 }: CompactSensorCardProps) {
   const sorted = [...readings].sort((a, b) => a.timestamp - b.timestamp);
   const latest = sorted[sorted.length - 1]?.[dataKey];
-  const first = sorted[0]?.[dataKey];
-  const hasTrend = sorted.length >= 2 && typeof latest === 'number' && typeof first === 'number';
-  const delta = hasTrend ? latest - first : 0;
-  const trendUp = delta >= 0;
+  const trend = computeTrend(readings, dataKey);
 
   return (
-    <div className={`p-4 rounded-xl border ${bgClassName} ${borderClassName}`}>
+    <div
+      className={`p-4 rounded-xl border ${bgClassName} ${borderClassName} transition-shadow duration-150 hover:shadow-md`}
+    >
       <div className="flex items-start justify-between mb-2">
         <div>
           <div className="text-xs text-gray-600 mb-0.5">{label}</div>
-          <div className="flex items-baseline gap-2">
+          <div className="flex items-baseline gap-1">
             <span className="text-2xl font-semibold text-gray-900">
               {typeof latest === 'number' ? latest.toFixed(decimals) : '-'}
-              <span className="text-base font-normal text-gray-500 ml-0.5">{unit}</span>
             </span>
-            {hasTrend && (
-              <div
-                className={`flex items-center gap-0.5 ${
-                  trendUp ? 'text-green-600' : 'text-red-600'
-                }`}
-              >
-                {trendUp ? (
-                  <TrendingUp className="w-3 h-3" />
-                ) : (
-                  <TrendingDown className="w-3 h-3" />
-                )}
-                <span className="text-xs font-medium">
-                  {trendUp ? '+' : ''}
-                  {delta.toFixed(decimals)}
-                  {unit === '°C' ? '°' : unit}
-                </span>
-              </div>
-            )}
+            <span className="text-base text-gray-500">{unit}</span>
           </div>
         </div>
-        <div className="text-right text-xs text-gray-500 shrink-0">
-          <div>Min: {min !== null ? min.toFixed(decimals) : '-'}</div>
-          <div>Max: {max !== null ? max.toFixed(decimals) : '-'}</div>
-        </div>
+        {trend && (
+          <span className="text-xs text-gray-500 mt-0.5" style={{ color }}>
+            {trend}
+          </span>
+        )}
       </div>
-      <div className="h-16 -mx-1">
-        <Sparkline readings={readings} dataKey={dataKey} color={color} height={64} />
+      <div className="h-20 -mx-1">
+        <Sparkline
+          readings={readings}
+          dataKey={dataKey}
+          color={color}
+          height={80}
+          interactive
+          unit={unit}
+        />
       </div>
     </div>
   );
@@ -80,10 +100,11 @@ function CompactSensorCard({
 
 interface CompactSensorPanelProps {
   readings: SensorReading[];
-  statistics: NodeStatistics | null;
+  // Kept for API compatibility / future use (e.g. stats-based labels)
+  statistics?: NodeStatistics | null;
 }
 
-function CompactSensorPanel({ readings, statistics }: CompactSensorPanelProps) {
+function CompactSensorPanel({ readings }: CompactSensorPanelProps) {
   if (readings.length === 0) return null;
 
   return (
@@ -93,8 +114,6 @@ function CompactSensorPanel({ readings, statistics }: CompactSensorPanelProps) {
         unit="°C"
         dataKey="temperature_celsius"
         readings={readings}
-        min={statistics?.temperature.min_celsius ?? null}
-        max={statistics?.temperature.max_celsius ?? null}
         color="#f97316"
         bgClassName="bg-gradient-to-br from-orange-50 to-white"
         borderClassName="border-orange-100"
@@ -104,8 +123,6 @@ function CompactSensorPanel({ readings, statistics }: CompactSensorPanelProps) {
         unit="%"
         dataKey="humidity_percent"
         readings={readings}
-        min={statistics?.humidity.min_percent ?? null}
-        max={statistics?.humidity.max_percent ?? null}
         color="#3b82f6"
         bgClassName="bg-gradient-to-br from-blue-50 to-white"
         borderClassName="border-blue-100"

--- a/dashboard/src/components/Sparkline.tsx
+++ b/dashboard/src/components/Sparkline.tsx
@@ -1,3 +1,5 @@
+import { useState, useRef } from 'react';
+import { format } from 'date-fns';
 import type { SensorReading } from '../types';
 
 interface SparklineProps {
@@ -7,6 +9,10 @@ interface SparklineProps {
   variant?: 'inline' | 'backdrop';
   /** Height in pixels (default: 40 for inline, 100% for backdrop) */
   height?: number;
+  /** Show hover dot + value tooltip on pointer move (inline only) */
+  interactive?: boolean;
+  /** Unit label for hover tooltip (e.g. "°C", "%") */
+  unit?: string;
 }
 
 /** Gap threshold in seconds — break the line if readings are >10 min apart */
@@ -67,34 +73,136 @@ function segmentToAreaPath(seg: PathSegment, height: number): string {
 }
 
 /** Inline sparkline: a small line chart rendered below the reading text */
-function InlineSparkline({ readings, dataKey, color = '#6366f1', height = 40 }: SparklineProps) {
+function InlineSparkline({
+  readings,
+  dataKey,
+  color = '#6366f1',
+  height = 40,
+  interactive = false,
+  unit = '',
+}: SparklineProps) {
   const width = 200;
-  const segments = buildSegments(readings, dataKey, width, height, 4);
+  const paddingY = 4;
+  const segments = buildSegments(readings, dataKey, width, height, paddingY);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
   if (segments.length === 0) return null;
 
+  // Sorted readings mirror buildSegments ordering so indices align for hover lookup
+  const sorted = [...readings].sort((a, b) => a.timestamp - b.timestamp);
+  const values = sorted.map((r) => r[dataKey]);
+  const valMin = Math.min(...values);
+  const valMax = Math.max(...values);
+  const valRange = valMax - valMin || 1;
+  const tMin = sorted[0].timestamp;
+  const tMax = sorted[sorted.length - 1].timestamp;
+  const tRange = tMax - tMin || 1;
+
+  const pointFor = (idx: number) => {
+    const x = ((sorted[idx].timestamp - tMin) / tRange) * width;
+    const y = height - paddingY - ((values[idx] - valMin) / valRange) * (height - paddingY * 2);
+    return { x, y };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!interactive || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const px = event.clientX - rect.left;
+    const hoverX = (px / rect.width) * width;
+    // Find nearest point by x
+    let nearest = 0;
+    let nearestDist = Infinity;
+    for (let i = 0; i < sorted.length; i++) {
+      const x = ((sorted[i].timestamp - tMin) / tRange) * width;
+      const dist = Math.abs(x - hoverX);
+      if (dist < nearestDist) {
+        nearestDist = dist;
+        nearest = i;
+      }
+    }
+    setHoverIdx(nearest);
+  };
+
+  const handlePointerLeave = () => setHoverIdx(null);
+
+  const hover = hoverIdx !== null ? pointFor(hoverIdx) : null;
+  const hoverReading = hoverIdx !== null ? sorted[hoverIdx] : null;
+  const hoverValue = hoverReading ? hoverReading[dataKey] : null;
+  // Position tooltip: flip to left edge if hover is in the right 40%
+  const tooltipLeftPct = hover ? (hover.x / width) * 100 : 0;
+  const tooltipAlignRight = tooltipLeftPct > 60;
+
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      className="w-full"
+    <div
+      ref={containerRef}
+      className="relative w-full"
       style={{ height }}
+      onPointerMove={interactive ? handlePointerMove : undefined}
+      onPointerLeave={interactive ? handlePointerLeave : undefined}
     >
-      {segments.map((seg, i) => (
-        <g key={i}>
-          <path d={segmentToAreaPath(seg, height)} fill={color} opacity={0.12} />
-          <path
-            d={segmentToLinePath(seg)}
-            fill="none"
-            stroke={color}
-            strokeWidth={1.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-          />
-        </g>
-      ))}
-    </svg>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className="w-full h-full block"
+      >
+        {segments.map((seg, i) => (
+          <g key={i}>
+            <path d={segmentToAreaPath(seg, height)} fill={color} opacity={0.12} />
+            <path
+              d={segmentToLinePath(seg)}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          </g>
+        ))}
+        {interactive && hover && (
+          <>
+            <line
+              x1={hover.x}
+              x2={hover.x}
+              y1={0}
+              y2={height}
+              stroke={color}
+              strokeOpacity={0.3}
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx={hover.x}
+              cy={hover.y}
+              r={3}
+              fill="white"
+              stroke={color}
+              strokeWidth={2}
+              vectorEffect="non-scaling-stroke"
+            />
+          </>
+        )}
+      </svg>
+      {interactive && hover && hoverReading && hoverValue !== null && (
+        <div
+          className="pointer-events-none absolute top-0 z-10 bg-white/95 border border-gray-200 shadow-sm rounded px-2 py-1 text-xs whitespace-nowrap"
+          style={
+            tooltipAlignRight
+              ? { right: `${100 - tooltipLeftPct}%`, marginRight: 6 }
+              : { left: `${tooltipLeftPct}%`, marginLeft: 6 }
+          }
+        >
+          <div className="font-medium text-gray-900">
+            {hoverValue.toFixed(1)}
+            {unit}
+          </div>
+          <div className="text-gray-500">
+            {format(new Date(hoverReading.timestamp * 1000), 'MMM d, HH:mm')}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Hover shadow on compact sensor cards
- Simplified card: just title, current value, trend label, and chart (removed min/max and delta number)
- Trend label computed from simple linear fit — Steady / Increasing / Decreasing / Fluctuating
- Sparkline gets an opt-in interactive mode: hover shows a guide line, dot on the nearest data point, and a floating tooltip with value + timestamp

Existing call sites (NodeCard sparkline) are unaffected since interactive mode is opt-in via prop.

## Test plan
- [ ] Hover over greenhouse node compact cards → card raises shadow
- [ ] Hover over the sparkline → dot + guide line + tooltip appears on nearest point
- [ ] Trend label updates as the time range changes
- [ ] NodeCard sparklines (on the nodes list) still render without hover UI
- [ ] Sensor node still shows full Plotly charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)