### PR TITLE
fix(hub): re-sequence pending updates when node is ahead of hub counter

### DIFF
--- a/src/lora/hub_router.cpp
+++ b/src/lora/hub_router.cpp
@@ -1,6 +1,7 @@
 #include "hub_router.h"
 
 #include <cstring>
+#include <utility>
 
 #include "pico/stdlib.h"
 
@@ -451,6 +452,31 @@ void HubRouter::handleCheckUpdates(uint16_t node_addr, uint8_t node_sequence)
 {
     auto &state = node_updates_[node_addr];
     state.last_check_time = bramble::util::time::currentTimeMs();
+
+    // If the node's sequence is at or ahead of our counter, the hub was likely
+    // restarted (or we've never assigned a sequence to this node before). Bump
+    // our counter above the node's and re-sequence any pending updates so they
+    // land in the node's "not yet processed" window. Without this, newly queued
+    // updates have low sequence numbers that the node (and the pop loop below)
+    // will treat as already-processed, silently discarding them.
+    if (node_sequence >= state.next_sequence && !state.pending_updates.empty()) {
+        uint8_t new_seq = static_cast<uint8_t>(node_sequence + 1);
+        std::queue<PendingUpdate> requeued;
+        size_t count = state.pending_updates.size();
+        while (!state.pending_updates.empty()) {
+            PendingUpdate update = state.pending_updates.front();
+            state.pending_updates.pop();
+            update.sequence = new_seq++;
+            requeued.push(update);
+        }
+        state.pending_updates = std::move(requeued);
+        state.next_sequence = new_seq;
+        logger.info("Node 0x%04X: resequenced %zu pending updates above node_seq=%d", node_addr,
+                    count, node_sequence);
+    } else if (node_sequence >= state.next_sequence) {
+        // No queued updates; just advance our counter so future queues are safe.
+        state.next_sequence = static_cast<uint8_t>(node_sequence + 1);
+    }
 
     // Remove updates that the node has already processed
     // Node sequence indicates the last update the node successfully applied


### PR DESCRIPTION
## Summary
Fixes a silent-drop of actuator commands after a hub reboot.

## Root cause
The hub's \`NodeUpdateState::next_sequence\` counter is runtime-only, resetting to 1 on hub reboot. The node's \`current_sequence\` persists within its session (typically much higher, e.g. 33 in the observed logs). When a command is then queued, it gets a low sequence (e.g. 2). On the next \`CHECK_UPDATES\`, the hub's pop-below-\`node_sequence\` loop treats the queued item as already-processed and discards it, responding with \`has_update=0\`.

Even worse: even if the hub *did* send it, the node would reject it at \`application_mode.cpp:215\` because \`hub_sequence (2) <= current_sequence (33)\`.

## Fix
In \`handleCheckUpdates\`, if the node's reported sequence is at or ahead of our \`next_sequence\`:
- Bump \`next_sequence\` above the node's
- Re-sequence any pending updates into the "not yet processed" window

Also handles the empty-queue case so future \`queue*\` calls assign safe sequence numbers.

## Test plan
- [ ] Reboot hub
- [ ] Send curtain open/close/stop from dashboard
- [ ] Confirm hub log shows \`resequenced N pending updates above node_seq=...\`
- [ ] Confirm node receives \`UPDATE_AVAILABLE: has_update=1, type=5\` and runs the command
- [ ] Confirm event appears in Recent Events

🤖 Generated with [Claude Code](https://claude.com/claude-code)