### PR TITLE
fix(greenhouse): move curtain pins to J7 header

### DIFF
--- a/src/board/bramble_v4_pins.h
+++ b/src/board/bramble_v4_pins.h
@@ -125,7 +125,7 @@ constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
 // --- Curtain motor pins (greenhouse variant, J7 header) ---
 // Relay-based motor reversing: one GPIO per direction
 // Silkscreen labels GPIO31/GPIO30 (v3 numbering); real RP2350B GPIOs are 39/38
-constexpr uint8_t PIN_CURTAIN_OPEN = J7::PIN_7;   // silkscreen GPIO31 → actual GPIO 39
-constexpr uint8_t PIN_CURTAIN_CLOSE = J7::PIN_8;  // silkscreen GPIO30 → actual GPIO 38
+constexpr uint8_t PIN_CURTAIN_OPEN = J7::PIN_6;   // J7 pin 6 → GPIO 40
+constexpr uint8_t PIN_CURTAIN_CLOSE = J7::PIN_8;  // J7 pin 8 → GPIO 38
 
 }  // namespace Board

--- a/src/board/bramble_v4_pins.h
+++ b/src/board/bramble_v4_pins.h
@@ -122,9 +122,10 @@ constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
     J7::PIN_5,  // VALVE_4 = GPIO 41
 };
 
-// --- Curtain motor pins (greenhouse variant, J8 header) ---
+// --- Curtain motor pins (greenhouse variant, J7 header) ---
 // Relay-based motor reversing: one GPIO per direction
-constexpr uint8_t PIN_CURTAIN_OPEN = J8::PIN_7;   // GPIO 22
-constexpr uint8_t PIN_CURTAIN_CLOSE = J8::PIN_8;  // GPIO 23
+// Silkscreen labels GPIO31/GPIO30 (v3 numbering); real RP2350B GPIOs are 39/38
+constexpr uint8_t PIN_CURTAIN_OPEN = J7::PIN_7;   // silkscreen GPIO31 → actual GPIO 39
+constexpr uint8_t PIN_CURTAIN_CLOSE = J7::PIN_8;  // silkscreen GPIO30 → actual GPIO 38
 
 }  // namespace Board


### PR DESCRIPTION
## Summary
- Moved curtain motor pins to J7 header (GPIO 39/38, then corrected OPEN to J7 pin 6 / GPIO 40)
- Verified working on greenhouse hardware

## Test plan
- [x] Greenhouse curtain open/close verified on hardware