### PR TITLE
fix(irrigation): UAF in re-registration callback + WAKE event classification

### DIFF
--- a/api/event_types.py
+++ b/api/event_types.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 class EventType(IntEnum):
     BOOT_COLD = 0x10
     BOOT_WATCHDOG = 0x11
+    WAKE = 0x12
     SENSOR_INIT_OK = 0x20
     SENSOR_INIT_FAIL = 0x21
     SENSOR_READ_OK = 0x22
@@ -37,6 +38,7 @@ class EventCode(IntEnum):
 EVENT_CODE_NAMES: dict[int, str] = {
     0x10: "Boot Cold",
     0x11: "Boot Watchdog",
+    0x12: "Wake",
     0x20: "Sensor Init Ok",
     0x21: "Sensor Init Fail",
     0x22: "Sensor Read Ok",

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -72,7 +72,8 @@ const EVENT_VISUALS: Record<number, EventVisual> = {
     color: 'text-amber-600',
     bgColor: 'bg-amber-50',
   },
-  [EventType.SLEEP_ENTER]: { icon: Moon, color: 'text-gray-600', bgColor: 'bg-gray-50' },
+  [EventType.WAKE]: { icon: Moon, color: 'text-gray-500', bgColor: 'bg-gray-50' },
+  [EventType.SLEEP_ENTER]: { icon: Moon, color: 'text-gray-500', bgColor: 'bg-gray-50' },
   // Sensor
   [EventType.SENSOR_INIT_OK]: {
     icon: Activity,
@@ -256,6 +257,53 @@ function PendingEventIcon({ status }: { status: 'pending' | 'confirmed' }) {
   );
 }
 
+// Event codes that collapse into summary rows (per-wake-cycle noise).
+const WAKE_CYCLE_CODES = new Set<number>([EventType.WAKE, EventType.SLEEP_ENTER]);
+
+type RenderItem =
+  | { kind: 'event'; event: NodeEvent }
+  | {
+      kind: 'collapsed';
+      events: NodeEvent[]; // consecutive run of WAKE/SLEEP_ENTER
+    };
+
+function collapseWakeCycles(dayEvents: NodeEvent[]): RenderItem[] {
+  const items: RenderItem[] = [];
+  let run: NodeEvent[] = [];
+  const flush = () => {
+    if (run.length === 0) return;
+    if (run.length === 1) {
+      items.push({ kind: 'event', event: run[0] });
+    } else {
+      items.push({ kind: 'collapsed', events: run });
+    }
+    run = [];
+  };
+  for (const event of dayEvents) {
+    if (WAKE_CYCLE_CODES.has(event.event_code)) {
+      run.push(event);
+    } else {
+      flush();
+      items.push({ kind: 'event', event });
+    }
+  }
+  flush();
+  return items;
+}
+
+function formatCollapsedLabel(events: NodeEvent[]): string {
+  const wakes = events.filter((e) => e.event_code === EventType.WAKE).length;
+  const sleeps = events.filter((e) => e.event_code === EventType.SLEEP_ENTER).length;
+  const fullCycles = Math.min(wakes, sleeps);
+  const leftover = events.length - fullCycles * 2;
+  if (fullCycles === 0) {
+    // Only wakes or only sleeps — unusual; just show count.
+    return `${events.length} wake/sleep events`;
+  }
+  const cycleLabel = fullCycles === 1 ? '1 wake/sleep cycle' : `${fullCycles} wake/sleep cycles`;
+  return leftover > 0 ? `${cycleLabel} + ${leftover}` : cycleLabel;
+}
+
 export function RecentEvents({ events, loading, pendingEvent }: RecentEventsProps) {
   // Filter out the real event that matches the pending one to avoid duplicates
   const filteredEvents = pendingEvent
@@ -361,39 +409,93 @@ export function RecentEvents({ events, loading, pendingEvent }: RecentEventsProp
                   )}
                 </AnimatePresence>
 
-                {dayEvents.map((event, index) => {
-                  const visual = EVENT_VISUALS[event.event_code] ?? DEFAULT_VISUAL;
-                  const Icon = visual.icon;
-                  const adjustedIndex = pendingEvent && day === 'Today' ? index + 1 : index;
-                  const totalItems = dayEvents.length + (pendingEvent && day === 'Today' ? 1 : 0);
-                  return (
-                    <div
-                      key={`${event.timestamp}-${event.event_code}-${index}`}
-                      className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
-                      style={{ animationDelay: `${index * 30}ms` }}
-                    >
-                      <div className="relative flex-shrink-0 mt-px">
-                        <div
-                          className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
-                        >
-                          <Icon className={`w-3 h-3 ${visual.color}`} />
-                        </div>
-                        {adjustedIndex < totalItems - 1 && (
-                          <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
-                        )}
-                      </div>
+                {(() => {
+                  const renderItems = collapseWakeCycles(dayEvents);
+                  return renderItems.map((item, index) => {
+                    const adjustedIndex =
+                      pendingEvent && day === 'Today' ? index + 1 : index;
+                    const totalItems =
+                      renderItems.length + (pendingEvent && day === 'Today' ? 1 : 0);
+                    const isLast = adjustedIndex >= totalItems - 1;
 
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between gap-2 mb-px">
-                          <span className="text-sm font-medium text-gray-900">
-                            {getEventName(event.event_code)}
-                          </span>
-                          <CopyableTimestamp timestamp={event.timestamp} />
+                    if (item.kind === 'collapsed') {
+                      // Use the most recent event's timestamp (events are typically reverse-chron).
+                      const first = item.events[0];
+                      const last = item.events[item.events.length - 1];
+                      // Times can be in either order; pick the older/newer by value.
+                      const olderTs = Math.min(first.timestamp, last.timestamp);
+                      const newerTs = Math.max(first.timestamp, last.timestamp);
+                      const visual = EVENT_VISUALS[EventType.WAKE] ?? DEFAULT_VISUAL;
+                      const Icon = visual.icon;
+                      return (
+                        <div
+                          key={`collapsed-${olderTs}-${newerTs}-${index}`}
+                          className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
+                          style={{ animationDelay: `${index * 30}ms` }}
+                        >
+                          <div className="relative flex-shrink-0 mt-px">
+                            <div
+                              className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
+                            >
+                              <Icon className={`w-3 h-3 ${visual.color}`} />
+                            </div>
+                            {!isLast && (
+                              <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
+                            )}
+                          </div>
+
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2 mb-px">
+                              <span className="text-sm font-medium text-gray-500">
+                                {formatCollapsedLabel(item.events)}
+                              </span>
+                              <span
+                                className="text-xs text-gray-400 font-mono"
+                                title={`${new Date(olderTs * 1000).toISOString()} – ${new Date(
+                                  newerTs * 1000
+                                ).toISOString()}`}
+                              >
+                                {format(new Date(olderTs * 1000), 'HH:mm')} –{' '}
+                                {format(new Date(newerTs * 1000), 'HH:mm')}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    }
+
+                    const event = item.event;
+                    const visual = EVENT_VISUALS[event.event_code] ?? DEFAULT_VISUAL;
+                    const Icon = visual.icon;
+                    return (
+                      <div
+                        key={`${event.timestamp}-${event.event_code}-${index}`}
+                        className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
+                        style={{ animationDelay: `${index * 30}ms` }}
+                      >
+                        <div className="relative flex-shrink-0 mt-px">
+                          <div
+                            className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
+                          >
+                            <Icon className={`w-3 h-3 ${visual.color}`} />
+                          </div>
+                          {!isLast && (
+                            <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
+                          )}
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-start justify-between gap-2 mb-px">
+                            <span className="text-sm font-medium text-gray-900">
+                              {getEventName(event.event_code)}
+                            </span>
+                            <CopyableTimestamp timestamp={event.timestamp} />
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  );
-                })}
+                    );
+                  });
+                })()}
               </div>
             </div>
           ))}

--- a/dashboard/src/generated/eventTypes.ts
+++ b/dashboard/src/generated/eventTypes.ts
@@ -3,6 +3,7 @@
 export const EventType = {
   BOOT_COLD: 0x10,
   BOOT_WATCHDOG: 0x11,
+  WAKE: 0x12,
   SENSOR_INIT_OK: 0x20,
   SENSOR_INIT_FAIL: 0x21,
   SENSOR_READ_OK: 0x22,
@@ -34,6 +35,7 @@ export const EventCode = {
 export const EVENT_CODE_NAMES: Record<number, string> = {
   0x10: 'Boot Cold',
   0x11: 'Boot Watchdog',
+  0x12: 'Wake',
   0x20: 'Sensor Init Ok',
   0x21: 'Sensor Init Fail',
   0x22: 'Sensor Read Ok',

--- a/src/modes/application_mode.cpp
+++ b/src/modes/application_mode.cpp
@@ -26,7 +26,10 @@ void ApplicationMode::run()
     // Record boot event — watchdog_caused_reboot() is only valid before watchdog_enable()
     if (watchdog_caused_reboot()) {
         event_log_.record(EventType::BOOT_WATCHDOG, 1, 0);
-    } else {
+    } else if (!defersBootEvent()) {
+        // Modes that don't differentiate cold-vs-warm boot get BOOT_COLD here.
+        // PMU-using modes override defersBootEvent() and record WAKE/BOOT_COLD
+        // themselves once state-restore validity is known.
         event_log_.record(EventType::BOOT_COLD, 0, 0);
     }
 

--- a/src/modes/application_mode.h
+++ b/src/modes/application_mode.h
@@ -116,6 +116,16 @@ protected:
     virtual void onStart() {}
 
     /**
+     * @brief Whether this mode defers the non-watchdog boot event to its own logic.
+     *
+     * Default: false — ApplicationMode::run() records BOOT_COLD for non-watchdog
+     * boots. PMU-using modes override to return true and record WAKE (warm boot
+     * from PMU sleep) or BOOT_COLD (no valid PMU state) themselves once state
+     * restore completes.
+     */
+    virtual bool defersBootEvent() const { return false; }
+
+    /**
      * @brief Called on each iteration of the main loop
      */
     virtual void onLoop() {}

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -116,6 +116,7 @@ void IrrigationMode::onStart()
             if (!success) {
                 pmu_logger.error("ClearToSend failed: %d", static_cast<int>(error));
                 // Proceed without PMU state — close all valves to establish known state
+                event_log_.record(EventType::BOOT_COLD, 0, 0);
                 valve_controller_.closeAllValves();
                 irrigation_state_.markInitialized();
             } else {
@@ -125,6 +126,7 @@ void IrrigationMode::onStart()
                 wake_timeout_id_ = task_queue_.postDelayed(
                     [this](uint32_t) -> bool {
                         pmu_logger.warn("WakeNotification timeout - proceeding without PMU state");
+                        event_log_.record(EventType::BOOT_COLD, 0, 0);
                         valve_controller_.closeAllValves();
                         wake_timeout_id_ = 0;
                         irrigation_state_.markInitialized();
@@ -136,6 +138,7 @@ void IrrigationMode::onStart()
     } else {
         logger.warn("PMU client not available - running without power management");
         // No PMU — close all valves to establish known state
+        event_log_.record(EventType::BOOT_COLD, 0, 0);
         valve_controller_.closeAllValves();
         irrigation_state_.markInitialized();
     }
@@ -328,10 +331,12 @@ void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEn
 
     if (restored) {
         pmu_logger.info("State restored from PMU");
+        event_log_.record(EventType::WAKE, 0, 0);
         // Re-evaluate registration need based on restored address
         needs_registration_ = (messenger_.getNodeAddress() == ADDRESS_UNREGISTERED);
     } else {
         pmu_logger.info("Cold start - no persisted state");
+        event_log_.record(EventType::BOOT_COLD, 0, 0);
         valve_controller_.closeAllValves();
     }
 

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -202,11 +202,15 @@ void IrrigationMode::onStateChange(IrrigationState state)
             // Set callback to advance SM when response arrives
             // Address is persisted via PMU state blob at sleep time (packState),
             // not flash — flash writes disrupt XIP cache on RP2350 and crash here.
+            // Do NOT clear the callback from within itself — that destroys the
+            // currently-executing std::function target, invalidating captured `this`
+            // and causing UAF on any subsequent member access. The state machine's
+            // state guard already rejects stale re-fires, and this callback is
+            // overwritten next time AWAITING_REGISTRATION is entered.
             messenger_.setRegistrationSuccessCallback([this](uint16_t new_address) {
                 logger.info("Re-registration assigned address 0x%04X", new_address);
                 // Reset update sequence — hub starts fresh for new address
                 update_state_.current_sequence = 0;
-                messenger_.setRegistrationSuccessCallback(nullptr);
                 irrigation_state_.reportReregistrationComplete();
             });
             break;

--- a/src/modes/irrigation_mode.h
+++ b/src/modes/irrigation_mode.h
@@ -110,6 +110,7 @@ public:
 protected:
     void onStart() override;
     void onLoop() override;
+    bool defersBootEvent() const override { return true; }
     void onActuatorCommand(const ActuatorPayload *payload) override;
     void onHeartbeatResponse(const HeartbeatResponsePayload *payload) override;
     void onReregistrationRequested() override;

--- a/src/util/event_record.h
+++ b/src/util/event_record.h
@@ -11,6 +11,7 @@ enum class EventType : uint8_t {
     // 0x1_ System
     BOOT_COLD = 0x10,
     BOOT_WATCHDOG = 0x11,
+    WAKE = 0x12,  // Warm boot from PMU sleep (RP2350 was power-cycled but PMU state restored)
 
     // 0x2_ Sensor
     SENSOR_INIT_OK = 0x20,


### PR DESCRIPTION
## Summary
- Fix silent UAF where the re-registration success lambda self-destructed its `std::function` slot mid-invocation, then used the freed `this` capture. The node got stuck in `AWAITING_REGISTRATION` forever after any hub-requested re-registration.
- Add `EventType::WAKE` and defer the non-watchdog boot event to mode-specific logic. `IrrigationMode` now records `WAKE` on successful PMU state restore and `BOOT_COLD` only on true cold starts, instead of treating every ~60s PMU wake as a cold boot.
- Collapse consecutive `WAKE`/`SLEEP_ENTER` runs in the dashboard's Recent Events into a single summary row so genuine events aren't drowned in wake-cycle noise.

## Test plan
- [x] IRRIGATION firmware builds clean (`build/bramble_irrigation_v4_sx1262.elf`)
- [x] Dashboard typechecks (`npx tsc --noEmit`)
- [ ] Flash to live node and observe clean `AWAITING_REGISTRATION -> SENDING_HEARTBEAT` transition when hub sets `PENDING_FLAG_REREGISTER`
- [ ] Verify dashboard collapses wake cycles into summary rows and non-cycle events still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)