### PR TITLE
feat(dashboard): time-windowed event fetching

### DIFF
--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -162,16 +162,65 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
     };
   }, [fetchData]);
 
+  const EVENT_WINDOW_SECONDS = 3600; // 1 hour per window
+  const [hasMoreEvents, setHasMoreEvents] = useState(true);
+  const [loadingMoreEvents, setLoadingMoreEvents] = useState(false);
+
+  const eventKey = (e: NodeEvent) => `${e.timestamp}-${e.event_code}-${e.data_hex ?? ''}`;
+
+  const mergeEvents = (fresh: NodeEvent[], prev: NodeEvent[]): NodeEvent[] => {
+    const seen = new Set<string>();
+    const merged: NodeEvent[] = [];
+    for (const e of fresh) {
+      const k = eventKey(e);
+      if (!seen.has(k)) { seen.add(k); merged.push(e); }
+    }
+    for (const e of prev) {
+      const k = eventKey(e);
+      if (!seen.has(k)) { seen.add(k); merged.push(e); }
+    }
+    merged.sort((a, b) => b.timestamp - a.timestamp);
+    return merged;
+  };
+
+  // Refresh: fetch the latest window and merge with any older loaded events.
   const fetchEvents = useCallback(async () => {
     try {
-      const response = await getNodeEvents(node.device_id, { limit: 200 });
-      setEvents(response.events);
+      const now = Math.floor(Date.now() / 1000);
+      const response = await getNodeEvents(node.device_id, {
+        startTime: now - EVENT_WINDOW_SECONDS,
+        limit: 1000,
+      });
+      setEvents((prev) => mergeEvents(response.events, prev));
     } catch {
       // Silently fail — events are informational
     } finally {
       setLoadingEvents(false);
     }
   }, [node.device_id]);
+
+  // Load older: extend backward by one window from the oldest loaded event.
+  const loadOlderEvents = useCallback(async () => {
+    if (loadingMoreEvents || !hasMoreEvents || events.length === 0) return;
+    setLoadingMoreEvents(true);
+    try {
+      const oldest = events[events.length - 1].timestamp;
+      const response = await getNodeEvents(node.device_id, {
+        startTime: oldest - EVENT_WINDOW_SECONDS,
+        endTime: oldest - 1,
+        limit: 1000,
+      });
+      if (response.events.length === 0) {
+        setHasMoreEvents(false);
+      } else {
+        setEvents((prev) => mergeEvents(response.events, prev));
+      }
+    } catch {
+      // Silently fail — events are informational
+    } finally {
+      setLoadingMoreEvents(false);
+    }
+  }, [node.device_id, events, hasMoreEvents, loadingMoreEvents]);
 
   useEffect(() => {
     fetchEvents();
@@ -708,7 +757,14 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
             </div>
           )}
 
-          <RecentEvents events={events} loading={loadingEvents} pendingEvent={pendingEvent} />
+          <RecentEvents
+            events={events}
+            loading={loadingEvents}
+            pendingEvent={pendingEvent}
+            onLoadMore={loadOlderEvents}
+            hasMore={hasMoreEvents}
+            loadingMore={loadingMoreEvents}
+          />
         </div>
       </div>
 

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -46,6 +46,9 @@ interface RecentEventsProps {
   events: NodeEvent[];
   loading: boolean;
   pendingEvent?: PendingEvent | null;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
 }
 
 type IconComponent = typeof Calendar;
@@ -304,7 +307,14 @@ function formatCollapsedLabel(events: NodeEvent[]): string {
   return leftover > 0 ? `${cycleLabel} + ${leftover}` : cycleLabel;
 }
 
-export function RecentEvents({ events, loading, pendingEvent }: RecentEventsProps) {
+export function RecentEvents({
+  events,
+  loading,
+  pendingEvent,
+  onLoadMore,
+  hasMore,
+  loadingMore,
+}: RecentEventsProps) {
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
   const toggleRun = (key: string) => {
     setExpandedRuns((prev) => {
@@ -563,6 +573,19 @@ export function RecentEvents({ events, loading, pendingEvent }: RecentEventsProp
               </div>
             </div>
           ))}
+
+          {onLoadMore && hasMore && (
+            <div className="pt-2 pb-1 flex justify-center">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={loadingMore}
+                className="text-xs text-gray-600 hover:text-gray-900 disabled:opacity-50 px-3 py-1 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                {loadingMore ? 'Loading…' : 'Load older'}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Switch events feed from `limit: 50` (count-based) to `startTime: now - 3600` (time-windowed). Fetches the full last hour of events instead of an arbitrary row count, so client-side collapse has complete data to work with.
- "Load older" extends backward by 1 hour per click instead of by row count.
- Extract `mergeEvents()` helper to deduplicate refresh/load-older merge logic.

No backend changes — the API already supported `start_time`/`end_time`; we just weren't using them.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Open dashboard, verify events load and collapse correctly for the last hour
- [ ] Click "Load older" — verify it loads the previous hour and appends

🤖 Generated with [Claude Code](https://claude.com/claude-code)