### PR TITLE
refactor: drop dead code and consolidate duplicated helpers

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <functional>
 
 #include "pico/stdlib.h"
 #include "pico/unique_id.h"
@@ -128,7 +129,8 @@ inline VariantInfo getVariantInfo()
 #elif HARDWARE_CONTROLLER
     return {NODE_TYPE_CONTROLLER, CAP_CONTROLLER | CAP_SCHEDULING, "Controller"};
 #elif HARDWARE_GREENHOUSE
-    return {NODE_TYPE_ACTUATOR, CAP_VALVE_CONTROL | CAP_TEMPERATURE | CAP_HUMIDITY, "Greenhouse Node"};
+    return {NODE_TYPE_ACTUATOR, CAP_VALVE_CONTROL | CAP_TEMPERATURE | CAP_HUMIDITY,
+            "Greenhouse Node"};
 #else
     return {NODE_TYPE_SENSOR, 0, "Generic Node"};
 #endif
@@ -139,6 +141,25 @@ bool initializeHardware(RadioInterface &lora, NeoPixel &led);
 uint64_t getDeviceId();
 bool attemptRegistration(ReliableMessenger &messenger, RadioInterface &lora,
                          NodeConfigManager &config_manager, uint64_t device_id);
+
+/**
+ * @brief Build the reregistration callback used by all modes.
+ *
+ * Resets the messenger to the unregistered address and resends a registration
+ * request to the hub. Invoked when the hub signals PENDING_FLAG_REREGISTER.
+ */
+inline std::function<void()> makeReregistrationCallback(ReliableMessenger &messenger,
+                                                        uint64_t device_id,
+                                                        const VariantInfo &variant)
+{
+    return [&messenger, device_id, variant]() {
+        printf("Re-registering with hub...\n");
+        messenger.setNodeAddress(ADDRESS_UNREGISTERED);
+        messenger.sendRegistrationRequest(ADDRESS_HUB, device_id, variant.node_type,
+                                          variant.capabilities, BRAMBLE_FIRMWARE_VERSION,
+                                          variant.variant_name);
+    };
+}
 
 /**
  * @brief Main entry point
@@ -278,15 +299,7 @@ int main()
             printf("Registered with address 0x%04X (stored in PMU RAM)\n", new_address);
         });
 
-        // Re-registration callback: hub doesn't recognize us, re-send registration
-        // Reset to unregistered address so we don't send from a stale address
-        auto reregistration_callback = [&messenger, device_id, variant]() {
-            printf("Re-registering with hub...\n");
-            messenger.setNodeAddress(ADDRESS_UNREGISTERED);
-            messenger.sendRegistrationRequest(ADDRESS_HUB, device_id, variant.node_type,
-                                              variant.capabilities, BRAMBLE_FIRMWARE_VERSION,
-                                              variant.variant_name);
-        };
+        auto reregistration_callback = makeReregistrationCallback(messenger, device_id, variant);
 
         // No registration attempt here - SensorMode handles it on cold start
         log.info("Starting SENSOR mode");
@@ -349,20 +362,12 @@ int main()
             log.info("Using saved address 0x%04X", current_address);
         }
 
-        // Re-registration callback: hub doesn't recognize us, re-send registration
-        // Reset to unregistered address so we don't send from a stale address
-        auto reregistration_callback = [&messenger, device_id, variant]() {
-            printf("Re-registering with hub...\n");
-            messenger.setNodeAddress(ADDRESS_UNREGISTERED);
-            messenger.sendRegistrationRequest(ADDRESS_HUB, device_id, variant.node_type,
-                                              variant.capabilities, BRAMBLE_FIRMWARE_VERSION,
-                                              variant.variant_name);
-        };
+        auto reregistration_callback = makeReregistrationCallback(messenger, device_id, variant);
 
 // Create appropriate node mode
 #ifdef HARDWARE_IRRIGATION
         log.info("Starting IRRIGATION mode");
-        IrrigationMode mode(messenger, lora, led, nullptr, nullptr, &network_stats, false);
+        IrrigationMode mode(messenger, lora, led, nullptr, nullptr, &network_stats);
         mode.setAddressSavedCallback([&config_manager, device_id](uint16_t new_address) {
             printf("Saving new address 0x%04X to flash\n", new_address);
             NodeConfiguration config;
@@ -377,7 +382,7 @@ int main()
         mode.run();
 #elif HARDWARE_GREENHOUSE
         log.info("Starting GREENHOUSE mode");
-        GreenhouseMode mode(messenger, lora, led, nullptr, nullptr, &network_stats, false);
+        GreenhouseMode mode(messenger, lora, led, nullptr, nullptr, &network_stats);
         mode.setReregistrationCallback(reregistration_callback);
         mode.run();
 #elif HARDWARE_CONTROLLER

--- a/src/modes/application_mode.cpp
+++ b/src/modes/application_mode.cpp
@@ -56,9 +56,6 @@ void ApplicationMode::run()
     state_machine_.markInitialized();
     updateStateMachine();
 
-    // If using multicore, start the task manager on Core 1
-    task_manager_.start();
-
     // Add LED update task if pattern exists
     if (led_pattern_) {
         task_manager_.addTask([this](uint32_t time) { updateLED(time); },
@@ -73,7 +70,7 @@ void ApplicationMode::run()
         // Call mode-specific loop hook
         onLoop();
 
-        // Update tasks (only if not using multicore)
+        // Dispatch periodic tasks
         task_manager_.update(current_time);
 
         // Check for interrupts first (more efficient than polling)

--- a/src/modes/application_mode.h
+++ b/src/modes/application_mode.h
@@ -52,9 +52,9 @@ public:
 
     ApplicationMode(ReliableMessenger &messenger, RadioInterface &lora, NeoPixel &led,
                     AddressManager *address_manager = nullptr, HubRouter *hub_router = nullptr,
-                    NetworkStats *network_stats = nullptr, bool use_multicore = false)
+                    NetworkStats *network_stats = nullptr)
         : messenger_(messenger), lora_(lora), led_(led), address_manager_(address_manager),
-          hub_router_(hub_router), network_stats_(network_stats), task_manager_(use_multicore)
+          hub_router_(hub_router), network_stats_(network_stats)
     {
     }
 

--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -2,10 +2,9 @@
 
 #include <cstring>
 
-#include "pico/unique_id.h"
-
 #include "hardware/watchdog.h"
 
+#include "../../main.h"
 #include "../board/board_pins.h"
 #include "../hal/flash.h"
 #include "../hal/logger.h"
@@ -17,17 +16,6 @@
 #include "../version.h"
 
 constexpr uint16_t HUB_ADDRESS = ADDRESS_HUB;
-
-static uint64_t getDeviceId()
-{
-    pico_unique_board_id_t board_id;
-    pico_get_unique_board_id(&board_id);
-    uint64_t id = 0;
-    for (int i = 0; i < 8; i++) {
-        id = (id << 8) | board_id.id[i];
-    }
-    return id;
-}
 constexpr uint32_t HEARTBEAT_INTERVAL_MS = 60000;  // 60 seconds
 
 static Logger logger("GREEN");

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -3,10 +3,10 @@
 #include <cstring>
 
 #include "pico/stdlib.h"
-#include "pico/unique_id.h"
 
 #include "hardware/watchdog.h"
 
+#include "../../main.h"
 #include "../hal/logger.h"
 #include "../hal/rtc_compat.h"
 #include "../led_patterns.h"
@@ -50,13 +50,8 @@ void IrrigationMode::onStart()
     logger.info("- PMU power management integration");
     logger.info("- Orange LED blink (init) -> Blue short blink (operational)");
 
-    // Cache device ID for heartbeat identification (big-endian, matching main.cpp registration)
-    pico_unique_board_id_t board_id;
-    pico_get_unique_board_id(&board_id);
-    device_id_ = 0;
-    for (int i = 0; i < 8; i++) {
-        device_id_ = (device_id_ << 8) | board_id.id[i];
-    }
+    // Cache device ID for heartbeat identification
+    device_id_ = ::getDeviceId();
 
     // Check if we need to register (no saved address — may be overridden by PMU state restore)
     needs_registration_ = (messenger_.getNodeAddress() == ADDRESS_UNREGISTERED);

--- a/src/periodic_task_manager.h
+++ b/src/periodic_task_manager.h
@@ -3,14 +3,12 @@
 #include <functional>
 #include <vector>
 
-#include "pico/multicore.h"
 #include "pico/sync.h"
 
 /**
  * @brief Manages periodic tasks with different intervals
  *
- * Can run on either core - if multicore is enabled, tasks run on Core 1
- * This keeps the main communication loop on Core 0 responsive
+ * Tasks are dispatched from the main loop on Core 0 via update().
  */
 class PeriodicTaskManager {
 public:
@@ -30,76 +28,10 @@ public:
 
 private:
     std::vector<Task> tasks_;
-    bool use_multicore_;
-    volatile bool running_;
     mutex_t task_mutex_;
 
-    /**
-     * @brief Core 1 entry point for multicore mode
-     */
-    static void core1_entry()
-    {
-        PeriodicTaskManager *manager = (PeriodicTaskManager *)multicore_fifo_pop_blocking();
-        manager->core1_loop();
-    }
-
-    /**
-     * @brief Core 1 main loop
-     */
-    void core1_loop()
-    {
-        while (running_) {
-            uint32_t current_time = to_ms_since_boot(get_absolute_time());
-
-            mutex_enter_blocking(&task_mutex_);
-            for (auto &task : tasks_) {
-                if (current_time - task.last_run >= task.interval_ms) {
-                    task.function(current_time);
-                    task.last_run = current_time;
-                }
-            }
-            mutex_exit(&task_mutex_);
-
-            // Sleep briefly to avoid hogging CPU
-            sleep_ms(10);
-        }
-    }
-
 public:
-    /**
-     * @brief Constructor
-     * @param use_multicore If true, run tasks on Core 1
-     */
-    explicit PeriodicTaskManager(bool use_multicore = false)
-        : use_multicore_(use_multicore), running_(false)
-    {
-        mutex_init(&task_mutex_);
-    }
-
-    ~PeriodicTaskManager() { stop(); }
-
-    /**
-     * @brief Start the task manager (launches Core 1 if multicore enabled)
-     */
-    void start()
-    {
-        if (use_multicore_ && !running_) {
-            running_ = true;
-            multicore_launch_core1(core1_entry);
-            multicore_fifo_push_blocking((uint32_t)this);
-        }
-    }
-
-    /**
-     * @brief Stop the task manager (stops Core 1 if multicore enabled)
-     */
-    void stop()
-    {
-        if (use_multicore_ && running_) {
-            running_ = false;
-            multicore_reset_core1();
-        }
-    }
+    PeriodicTaskManager() { mutex_init(&task_mutex_); }
 
     /**
      * @brief Add a periodic task
@@ -115,21 +47,19 @@ public:
     }
 
     /**
-     * @brief Update all tasks (only used in single-core mode)
+     * @brief Update all tasks — call from the main loop each iteration.
      * @param current_time Current system time in milliseconds
      */
     void update(uint32_t current_time)
     {
-        if (!use_multicore_) {
-            mutex_enter_blocking(&task_mutex_);
-            for (auto &task : tasks_) {
-                if (current_time - task.last_run >= task.interval_ms) {
-                    task.function(current_time);
-                    task.last_run = current_time;
-                }
+        mutex_enter_blocking(&task_mutex_);
+        for (auto &task : tasks_) {
+            if (current_time - task.last_run >= task.interval_ms) {
+                task.function(current_time);
+                task.last_run = current_time;
             }
-            mutex_exit(&task_mutex_);
         }
+        mutex_exit(&task_mutex_);
     }
 
     /**


### PR DESCRIPTION
## Summary

Three small, mechanical simplifications found while scanning the codebase — no behaviour change, just less code to maintain.

- **Remove dead `use_multicore` path.** `PeriodicTaskManager` had a whole Core-1 launch path (`start()`, `stop()`, `core1_entry()`, `core1_loop()`) gated on `use_multicore_`, which no caller ever sets to `true`. Dropped the parameter, the member, the Core-1 entry points, and the `#include "pico/multicore.h"`. `ApplicationMode` no longer takes or forwards the flag; two call sites in `main.cpp` that were passing an explicit `false` are now parameterless.

- **Consolidate `getDeviceId()`.** A global helper already exists at `main.h:19` / `main.cpp:484`, and `SensorMode` uses it. `GreenhouseMode` had a file-static copy (byte-identical), and `IrrigationMode::onStart()` inlined the same 8-byte big-endian loop to populate `device_id_`. Both now call `::getDeviceId()` and drop their `pico/unique_id.h` include.

- **Extract `makeReregistrationCallback()`.** The sensor and non-sensor branches in `main.cpp` each constructed an identical 7-line lambda for the hub-requested re-registration flow. Hoisted into a single inline helper; each branch is now one line.

## Why

Each of these was confirmed dead or duplicated by reading the code — no speculative refactoring. `use_multicore` in particular has been shipping inert Core-1 plumbing in every variant binary.

## Test plan

- [x] `cmake -B build -DHARDWARE_VARIANT=ALL && cmake --build build -j8` — all six variants link clean (SENSOR, IRRIGATION, CONTROLLER, HUB, GREENHOUSE, GENERIC)
- [ ] Smoke-test on hardware that heartbeat + re-registration still work (the callback helper is a straight hoist, should be identical behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)