### PR TITLE
feat(dashboard): show valve id, duration, and seconds in event log

### DIFF
--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -26,7 +26,14 @@ import { format, isToday, isYesterday } from 'date-fns';
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import type { NodeEvent } from '../types';
-import { getEventName, EventType, EventCode } from '../types';
+import {
+  getEventName,
+  getEventDetail,
+  parseEventDetail,
+  formatDuration,
+  EventType,
+  EventCode,
+} from '../types';
 import type { CurtainAction } from './CurtainControl';
 
 export interface PendingEvent {
@@ -211,7 +218,7 @@ function CopyableTimestamp({ timestamp }: { timestamp: number }) {
       className="group/ts flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 transition-colors font-mono"
       title={`Click to copy UTC: ${isoString}`}
     >
-      <span>{format(date, 'HH:mm')}</span>
+      <span>{format(date, 'HH:mm:ss')}</span>
       {copied ? (
         <Check className="w-3 h-3 text-green-600" />
       ) : (
@@ -263,6 +270,36 @@ function PendingEventIcon({ status }: { status: 'pending' | 'confirmed' }) {
 // Event codes that collapse into summary rows (per-wake-cycle noise).
 const WAKE_CYCLE_CODES = new Set<number>([EventType.WAKE, EventType.SLEEP_ENTER]);
 
+// Pair VALVE_OPEN events with the next matching VALVE_CLOSE / VALVE_TIMER_CLOSE
+// (same valve_id) to derive a duration. Events arrive newest-first.
+// Returns a map keyed by the OPEN event's timestamp -> duration in seconds.
+function annotateDurations(events: NodeEvent[]): Map<number, number> {
+  const durationByOpenTs = new Map<number, number>();
+  const openByValve = new Map<number, NodeEvent>();
+  // Walk oldest -> newest so opens come before closes.
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    const valveId = parseEventDetail(event.data_hex);
+    if (valveId === null) continue;
+    if (event.event_code === EventType.VALVE_OPEN) {
+      openByValve.set(valveId, event);
+    } else if (
+      event.event_code === EventType.VALVE_CLOSE ||
+      event.event_code === EventType.VALVE_TIMER_CLOSE
+    ) {
+      const open = openByValve.get(valveId);
+      if (open) {
+        const duration = event.timestamp - open.timestamp;
+        if (duration > 0) {
+          durationByOpenTs.set(open.timestamp, duration);
+        }
+        openByValve.delete(valveId);
+      }
+    }
+  }
+  return durationByOpenTs;
+}
+
 type RenderItem =
   | { kind: 'event'; event: NodeEvent }
   | {
@@ -292,6 +329,22 @@ function collapseWakeCycles(dayEvents: NodeEvent[]): RenderItem[] {
   }
   flush();
   return items;
+}
+
+// Compose the trailing detail string for an event row — valve/schedule id and,
+// for an OPEN with a known matching close, the watering duration.
+function eventLabelSuffix(
+  event: NodeEvent,
+  durationByOpenTs: Map<number, number>
+): string {
+  const parts: string[] = [];
+  const detail = getEventDetail(event.event_code, event.data_hex);
+  if (detail) parts.push(detail);
+  if (event.event_code === EventType.VALVE_OPEN) {
+    const dur = durationByOpenTs.get(event.timestamp);
+    if (dur !== undefined) parts.push(formatDuration(dur));
+  }
+  return parts.length ? ` · ${parts.join(' · ')}` : '';
 }
 
 function formatCollapsedLabel(events: NodeEvent[]): string {
@@ -338,6 +391,9 @@ export function RecentEvents({
           )
       )
     : events;
+
+  // Computed once over all events so pairs spanning day boundaries still resolve.
+  const durationByOpenTs = annotateDurations(filteredEvents);
 
   const groupedEvents = filteredEvents.reduce(
     (acc, event) => {
@@ -484,8 +540,8 @@ export function RecentEvents({
                                     newerTs * 1000
                                   ).toISOString()}`}
                                 >
-                                  {format(new Date(olderTs * 1000), 'HH:mm')} –{' '}
-                                  {format(new Date(newerTs * 1000), 'HH:mm')}
+                                  {format(new Date(olderTs * 1000), 'HH:mm:ss')} –{' '}
+                                  {format(new Date(newerTs * 1000), 'HH:mm:ss')}
                                 </span>
                               </div>
                             </div>
@@ -524,6 +580,7 @@ export function RecentEvents({
                                         <div className="flex items-start justify-between gap-2 mb-px">
                                           <span className="text-xs text-gray-600">
                                             {getEventName(event.event_code)}
+                                            {eventLabelSuffix(event, durationByOpenTs)}
                                           </span>
                                           <CopyableTimestamp timestamp={event.timestamp} />
                                         </div>
@@ -562,6 +619,7 @@ export function RecentEvents({
                           <div className="flex items-start justify-between gap-2 mb-px">
                             <span className="text-sm font-medium text-gray-900">
                               {getEventName(event.event_code)}
+                              {eventLabelSuffix(event, durationByOpenTs)}
                             </span>
                             <CopyableTimestamp timestamp={event.timestamp} />
                           </div>

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -246,12 +246,41 @@ export interface NodeEventsResponse {
 
 // Event code display names are generated from C++ headers.
 // Regenerate with `python3 tools/gen_event_types.py`.
-import { EVENT_CODE_NAMES } from '../generated/eventTypes';
+import { EVENT_CODE_NAMES, EventType } from '../generated/eventTypes';
 export { EVENT_CODE_NAMES, EventType, EventCode } from '../generated/eventTypes';
 
 export function getEventName(code: number): string {
   return EVENT_CODE_NAMES[code] || `Event 0x${code.toString(16).padStart(4, '0')}`;
 }
+
+// Decode the `detail` byte of an event payload (lower 16 bits of data_hex,
+// after the severity byte). Returns null if data_hex is missing/malformed.
+export function parseEventDetail(dataHex: string | null | undefined): number | null {
+  if (!dataHex || dataHex.length < 6) return null;
+  const parsed = parseInt(dataHex.slice(2, 6), 16);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+// Human-readable suffix for the event row (e.g. "Valve 1", "#3").
+// Returns null when there's nothing useful to show.
+export function getEventDetail(code: number, dataHex: string | null | undefined): string | null {
+  const detail = parseEventDetail(dataHex);
+  if (detail === null) return null;
+  switch (code) {
+    case EventType.VALVE_OPEN:
+    case EventType.VALVE_CLOSE:
+    case EventType.VALVE_TIMER_SET:
+    case EventType.VALVE_TIMER_CLOSE:
+      return `Valve ${detail + 1}`;
+    case EventType.SCHEDULE_APPLIED:
+    case EventType.SCHEDULE_REMOVED:
+    case EventType.SCHEDULE_FAILED:
+      return `#${detail}`;
+    default:
+      return null;
+  }
+}
+
 
 // Irrigation schedule types
 export interface IrrigationSchedule {

--- a/plans/event_detail_display.md
+++ b/plans/event_detail_display.md
@@ -1,0 +1,174 @@
+# Event detail display
+
+## Goal
+
+Make `Recent Events` in the dashboard show useful detail per event:
+
+1. **Sub-minute timestamps** — 11 events in the screenshot all read `19:03`. We have
+   second-precision data; we're just rendering `HH:mm`.
+2. **Watering duration** — for a VALVE_OPEN / VALVE_TIMER_SET, surface how long the
+   watering ran (or is running). Today there's no way to tell `15min` schedule from
+   `5min Run` from the event log alone.
+3. **Which valve** — events say "Valve Open" with no valve ID. We have the ID, we're
+   not displaying it.
+
+## What we have on the wire today
+
+`src/util/event_record.h`:
+
+```cpp
+struct EventRecord {
+    uint16_t uptime_offset;  // seconds since time reference
+    uint8_t  event_type;     // EventType enum
+    uint8_t  severity;       // 0/1/2
+    uint16_t detail;         // event-specific
+};  // 6 bytes packed
+```
+
+Hub serial bridge (`api/serial_interface.py:494-502`) packs `severity` + `detail`
+into `data_hex` like `"000003"` and stores it in the `node_events` row. The
+dashboard receives `NodeEvent { device_id, timestamp, event_code, data_hex }`
+(`dashboard/src/types/index.ts:233`) but **never reads `data_hex`**.
+
+For irrigation events the `detail` field currently carries:
+
+| EventType         | detail meaning           | source                              |
+|-------------------|--------------------------|-------------------------------------|
+| VALVE_OPEN        | valve_id                 | `irrigation_mode.cpp:448, 358`      |
+| VALVE_CLOSE       | valve_id                 | `irrigation_mode.cpp:453`           |
+| VALVE_TIMER_SET   | valve_id                 | `irrigation_mode.cpp:237`           |
+| VALVE_TIMER_CLOSE | valve_id                 | `irrigation_mode.cpp:345`           |
+| SCHEDULE_APPLIED  | schedule index           | `irrigation_mode.cpp:552`           |
+| SCHEDULE_REMOVED  | schedule index           | `irrigation_mode.cpp:579`           |
+| SCHEDULE_FAILED   | schedule index           | `irrigation_mode.cpp:558, 583`      |
+
+**Duration is not on the wire.** It has to be added.
+
+Timestamps already have second precision end-to-end — only the render is truncated
+(`dashboard/src/components/RecentEvents.tsx:214`, `:487-488`).
+
+## Approach
+
+Three independent changes, do them in order — each is shippable on its own.
+
+### 1. Render `HH:mm:ss` instead of `HH:mm`
+
+Trivial. Two `format(date, 'HH:mm')` call sites in `RecentEvents.tsx`:
+- `:214` — single event row (`CopyableTimestamp`)
+- `:487-488` — collapsed wake/sleep range label
+
+Risk: the row gets a few pixels wider. Mono font already; should fit.
+
+### 2. Render detail in the event label
+
+Decode `data_hex` (already on `NodeEvent`) and append context:
+
+- `VALVE_OPEN | VALVE_CLOSE | VALVE_TIMER_SET | VALVE_TIMER_CLOSE` → `"Valve N"` suffix (e.g. `"Valve Open · Valve 1"`)
+- `SCHEDULE_APPLIED | SCHEDULE_REMOVED | SCHEDULE_FAILED` → `"#<index>"` suffix
+
+Helper in `dashboard/src/types/index.ts` (next to `getEventName`):
+
+```ts
+export function getEventDetail(code: number, dataHex: string): string | null {
+  if (!dataHex || dataHex.length < 6) return null;
+  const detail = parseInt(dataHex.slice(2, 6), 16);
+  switch (code) {
+    case EventType.VALVE_OPEN:
+    case EventType.VALVE_CLOSE:
+    case EventType.VALVE_TIMER_SET:
+    case EventType.VALVE_TIMER_CLOSE:
+      return `Valve ${detail + 1}`;            // 1-indexed for display
+    case EventType.SCHEDULE_APPLIED:
+    case EventType.SCHEDULE_REMOVED:
+    case EventType.SCHEDULE_FAILED:
+      return `#${detail}`;
+    default:
+      return null;
+  }
+}
+```
+
+Render site is the event row span in `RecentEvents.tsx:564` and `:526` (collapsed
+expansion). Append the detail with a subtle separator if non-null.
+
+Decision needed: 0- or 1-indexed? Schedules list in screenshot already shows
+`Valve 1 / Valve 2` (1-indexed) so match that.
+
+### 3. Add duration to watering events
+
+Two sub-options. Pick one.
+
+**Option A — Pair on the dashboard.** Walk the event list; for each
+`VALVE_OPEN(valve=X)` find the next `VALVE_TIMER_CLOSE(valve=X)` or
+`VALVE_CLOSE(valve=X)` and compute `close.timestamp - open.timestamp`. Render
+as `"Valve Open · Valve 1 · 60s"`.
+
+- Pro: no firmware/protocol change. Works for events already in DB.
+- Con: ambiguous if pairs span page boundaries (loadMore). Ambiguous if events arrive out of order or get dropped.
+- Edge cases: open with no matching close → `"ongoing"`; close with no open → leave bare.
+
+**Option B — Encode duration on the wire.** Repurpose the 16-bit `detail` to pack
+both valve ID and duration. 4 bits valve (16 valves max — we use 4), 12 bits
+duration in 4-second units = ~68 minutes max. For schedules that go longer,
+saturate. Or use 16 bits for duration on `VALVE_TIMER_SET` only (drop valve ID
+from that event — duration is the interesting bit, valve ID is implicit from the
+preceding `VALVE_OPEN`).
+
+- Pro: exact, no pairing logic.
+- Con: protocol change. Need to update node firmware (`irrigation_mode.cpp:237, 232-239`), serial bridge (`api/serial_interface.py:494-502`), regenerate types.
+
+**Recommendation: A first.** Most watering events come in pairs within one TX batch
+(open → sleep enter → ... → wake → valve timer close, all in one wake cycle's
+event log). Dashboard pairing covers 90% of real use. Revisit B if pairing
+quality is poor in practice.
+
+For Option A, the pairing function lives in `RecentEvents.tsx` next to
+`collapseWakeCycles`. Pseudo:
+
+```ts
+function annotateDurations(events: NodeEvent[]): Map<number, number> {
+  // events assumed sorted desc by timestamp (as the API returns them)
+  const durationByOpenTs = new Map<number, number>();
+  const openByValve = new Map<number, NodeEvent>();
+  // walk oldest→newest, so reverse iterate
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    const valveId = parseInt(e.data_hex.slice(2, 6), 16);
+    if (e.event_code === EventType.VALVE_OPEN) {
+      openByValve.set(valveId, e);
+    } else if (
+      e.event_code === EventType.VALVE_CLOSE ||
+      e.event_code === EventType.VALVE_TIMER_CLOSE
+    ) {
+      const open = openByValve.get(valveId);
+      if (open) {
+        durationByOpenTs.set(open.timestamp, e.timestamp - open.timestamp);
+        openByValve.delete(valveId);
+      }
+    }
+  }
+  return durationByOpenTs;
+}
+```
+
+Render: if `durationByOpenTs.has(event.timestamp)` and `event.event_code === VALVE_OPEN`,
+append `· ${formatDuration(duration)}` (e.g. `60s`, `5m`, `15m 30s`).
+
+## Open questions for the user
+
+1. **1-indexed valves in display?** (Schedules already show `Valve 1` / `Valve 2`.)
+2. **Where to put detail in the row** — same line (`"Valve Open · Valve 1 · 60s"`)
+   or a second line under the event name? Single-line is more scannable; second
+   line gives more breathing room when many events stack.
+3. **Pairing only (Option A) or wire-format duration (Option B)?** Auto-mode-friendly
+   if A; B requires firmware reflash on all irrigation nodes.
+
+## File touch list
+
+- `dashboard/src/types/index.ts` — add `getEventDetail`, `formatDuration` helpers
+- `dashboard/src/components/RecentEvents.tsx` — sub-minute timestamps + detail + duration
+
+If Option B is chosen later:
+- `src/modes/irrigation_mode.cpp` — pack duration into detail
+- `api/serial_interface.py` — unchanged (still ships `severity:detail`)
+- `dashboard/src/types/index.ts` — decode new layout


### PR DESCRIPTION
## Summary
- Dashboard `Recent Events` rows now show second-precision timestamps (`HH:mm:ss`), so the 11-events-at-19:03 case is distinguishable
- Each row's label gains a detail suffix: `Valve N` (1-indexed) for VALVE_* events, `#idx` for SCHEDULE_* events — decoded from the `detail` byte already on the wire (`data_hex`)
- Valve open events pair with the next matching close/timer-close to compute watering duration; rendered as e.g. `Valve Open · Valve 1 · 2min`

Plan: `plans/event_detail_display.md`.

## Test plan
- [ ] Run `npm run dev` in `dashboard/`, open a node page, confirm `Recent Events` shows seconds + valve detail + durations
- [ ] Trigger a manual watering from the dashboard, confirm the OPEN row shows the duration once the close arrives
- [ ] Confirm collapsed wake/sleep run timestamps also show seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)