### PR TITLE
feat(activity-log): persist ad-hoc commands and merge with events

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -820,10 +820,19 @@ def run_valve(device_id: int):
         if not 1 <= duration_seconds <= 7200:
             return jsonify({'error': 'duration_seconds must be 1-7200'}), 400
 
+        # Record the command in the audit log BEFORE queueing so the dashboard
+        # can surface "pending" state immediately on poll.
+        from command_queue import queue_send_actuator, COMMAND_TTL_DEFAULTS
+        db = get_database()
+        command_id = db.insert_command(
+            device_id=device_id,
+            command_type='valve_open',
+            params={'valve': valve, 'duration_seconds': duration_seconds},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['valve_open'],
+        )
+
         # Send actuator ON command with duration — firmware sets RTC Alarm A
         # for auto-close after the specified duration (node sleeps in between)
-        from command_queue import queue_send_actuator
-
         actuator_type = 1  # ACTUATOR_VALVE
         command = 1  # CMD_TURN_ON
         result = queue_send_actuator(
@@ -834,9 +843,13 @@ def run_valve(device_id: int):
             duration_seconds=duration_seconds,
         )
 
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'device_id': str(device_id),
             'address': address,
             'valve': valve,
@@ -875,7 +888,14 @@ def stop_valve(device_id: int):
         if valve is None or valve not in (0, 1):
             return jsonify({'error': 'valve must be 0 or 1'}), 400
 
-        from command_queue import queue_send_actuator
+        from command_queue import queue_send_actuator, COMMAND_TTL_DEFAULTS
+        db = get_database()
+        command_id = db.insert_command(
+            device_id=device_id,
+            command_type='valve_close',
+            params={'valve': valve},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['valve_close'],
+        )
 
         actuator_type = 1  # ACTUATOR_VALVE
         command = 0  # CMD_TURN_OFF
@@ -886,9 +906,13 @@ def stop_valve(device_id: int):
             param=valve,
         )
 
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'device_id': str(device_id),
             'address': address,
             'valve': valve,
@@ -933,13 +957,24 @@ def set_wake_interval(device_id: int):
             return jsonify({'error': 'interval_seconds must be 10-3600'}), 400
 
         # Queue command for delivery (uses address for hub routing)
-        from command_queue import queue_set_wake_interval
+        from command_queue import queue_set_wake_interval, COMMAND_TTL_DEFAULTS
+        db = get_database()
+        command_id = db.insert_command(
+            device_id=device_id,
+            command_type='wake_interval',
+            params={'interval_seconds': interval},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['wake_interval'],
+        )
 
         result = queue_set_wake_interval(node_address=address, interval_seconds=interval)
+
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
 
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'device_id': str(device_id),  # String to preserve JS precision
             'address': address,
             'interval_seconds': interval,
@@ -1104,7 +1139,33 @@ def control_curtain(address: int):
         return jsonify({'error': f'Invalid action: {action}. Must be open, close, stop, or calibrate'}), 400
 
     try:
-        from command_queue import queue_send_actuator
+        from command_queue import queue_send_actuator, COMMAND_TTL_DEFAULTS
+
+        # Reverse-lookup device_id from address so we can write a row to the
+        # node_commands audit log. If lookup fails, skip the insert and warn
+        # — don't fail the POST itself.
+        db = get_database()
+        command_id = None
+        try:
+            with db._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT device_id FROM nodes WHERE address = ?",
+                    (address,),
+                ).fetchone()
+            if row:
+                command_id = db.insert_command(
+                    device_id=int(row[0]),
+                    command_type='curtain',
+                    params={'action': action},
+                    ttl_seconds=COMMAND_TTL_DEFAULTS['curtain'],
+                )
+            else:
+                logger.warning(
+                    f"Curtain command: no device_id for address {address}, "
+                    "skipping audit-log insert"
+                )
+        except Exception as e:
+            logger.warning(f"Curtain command audit-log insert failed: {e}")
 
         actuator_type = 4  # ACTUATOR_CURTAIN
         command = action_map[action]
@@ -1114,9 +1175,13 @@ def control_curtain(address: int):
             command=command,
         )
 
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'node_address': address,
             'action': action,
             'message': f'Curtain {action} command queued for delivery'
@@ -1167,6 +1232,59 @@ def get_node_events(device_id: int):
 
     except Exception as e:
         logger.error(f"Error querying events for device {device_id}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/nodes/<int:device_id>/commands', methods=['GET'])
+def get_node_commands(device_id: int):
+    """Query the ad-hoc command audit log for a node.
+
+    Query parameters:
+        status: CSV of statuses to include (pending,confirmed,failed,expired,cancelled)
+        since: Earliest created_at to include (unix seconds). Defaults to now-86400.
+        limit: Maximum records (default 100, max 200)
+
+    Returns:
+        JSON object {device_id, count, commands: [...]}
+    """
+    try:
+        db = get_database()
+
+        # Sweep expired pending rows opportunistically so callers see fresh state
+        # without needing a background thread. Cheap indexed UPDATE.
+        try:
+            db.expire_stale_commands(int(time.time()))
+        except Exception as e:
+            logger.warning(f"Expire sweep failed: {e}")
+
+        status_csv = request.args.get('status')
+        status_list = (
+            [s.strip() for s in status_csv.split(',') if s.strip()]
+            if status_csv
+            else None
+        )
+        since = request.args.get('since', type=int)
+        if since is None:
+            since = int(time.time()) - 86400
+        limit = request.args.get('limit', default=100, type=int)
+        if limit < 1 or limit > 200:
+            return jsonify({'error': 'limit must be 1-200'}), 400
+
+        commands = db.query_commands(
+            device_id=device_id,
+            status=status_list,
+            since=since,
+            limit=limit,
+        )
+
+        return jsonify({
+            'device_id': str(device_id),
+            'count': len(commands),
+            'commands': commands,
+        })
+
+    except Exception as e:
+        logger.error(f"Error querying commands for device {device_id}: {e}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/api/command_queue.py
+++ b/api/command_queue.py
@@ -20,6 +20,18 @@ huey = SqliteHuey(
 # The API service is reachable at http://api:5000 from within the Docker network
 API_BASE_URL = "http://api:5000"
 
+# Default TTLs for the node_commands audit table — how long we wait for a
+# confirming event from the node before marking the command 'expired'.
+# Tuned to typical wake intervals: valve commands tolerate up to 30 min of
+# node sleep; curtain nodes are usually mains-powered and react fast;
+# wake_interval has no confirming event today so it always expires by design.
+COMMAND_TTL_DEFAULTS = {
+    'valve_open': 1800,
+    'valve_close': 1800,
+    'curtain': 600,
+    'wake_interval': 300,
+}
+
 
 def _send_via_api(command: str, command_id: str) -> dict:
     """Send a hub command through the API's serial connection.

--- a/api/database.py
+++ b/api/database.py
@@ -1,5 +1,6 @@
 """DuckDB database for sensor data storage."""
 import duckdb
+import json
 import logging
 import time
 import threading
@@ -223,6 +224,31 @@ class SensorDatabase:
         confirmed_at INTEGER,
         PRIMARY KEY (device_id, schedule_index)
     );
+
+    -- Audit trail for ad-hoc dashboard commands (valve run/stop, curtain,
+    -- wake-interval). Schedules stay in their own table; this is the
+    -- equivalent lifecycle log for fire-and-forget commands so the user
+    -- can see "pending" state during the dead zone between click and the
+    -- node's confirming event.
+    CREATE TABLE IF NOT EXISTS node_commands (
+        id BIGINT PRIMARY KEY,
+        device_id UBIGINT NOT NULL,
+        command_type VARCHAR NOT NULL,
+        params VARCHAR NOT NULL,
+        status VARCHAR NOT NULL DEFAULT 'pending',
+        created_at INTEGER NOT NULL,
+        confirmed_at INTEGER,
+        expires_at INTEGER NOT NULL,
+        huey_task_id VARCHAR,
+        confirming_event_code INTEGER,
+        confirming_event_detail INTEGER
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_cmds_device_created
+        ON node_commands(device_id, created_at);
+
+    CREATE INDEX IF NOT EXISTS idx_cmds_pending_match
+        ON node_commands(device_id, status, command_type);
     """
 
     def __init__(self, db_path: str = Config.SENSOR_DB_PATH):
@@ -256,13 +282,15 @@ class SensorDatabase:
     def _init_id_counter(self, conn: duckdb.DuckDBPyConnection):
         """Initialize ID counter from existing data.
 
-        The counter is shared across sensor_readings and node_events, so
-        seed from the MAX(id) of both to avoid primary-key collisions.
+        The counter is shared across sensor_readings, node_events, and
+        node_commands, so seed from the MAX(id) of all three to avoid
+        primary-key collisions.
         """
         result = conn.execute("""
             SELECT GREATEST(
                 COALESCE((SELECT MAX(id) FROM sensor_readings), 0),
-                COALESCE((SELECT MAX(id) FROM node_events), 0)
+                COALESCE((SELECT MAX(id) FROM node_events), 0),
+                COALESCE((SELECT MAX(id) FROM node_commands), 0)
             )
         """).fetchone()
         if result and result[0]:
@@ -1433,6 +1461,220 @@ class SensorDatabase:
         except duckdb.Error as e:
             logger.error(f"Failed to query events: {e}")
             return []
+
+    # ------------------------------------------------------------------
+    # Node commands — audit trail for ad-hoc dashboard commands.
+    # ------------------------------------------------------------------
+
+    def insert_command(self, device_id: int, command_type: str,
+                       params: dict, ttl_seconds: int,
+                       huey_task_id: Optional[str] = None) -> Optional[int]:
+        """Record a dashboard-issued command and return its id.
+
+        Args:
+            device_id: Device identifier
+            command_type: 'valve_open' | 'valve_close' | 'curtain' | 'wake_interval'
+            params: Command-specific parameters, JSON-serialisable
+            ttl_seconds: How long to wait for confirmation before marking expired
+            huey_task_id: Huey task id once enqueued (may be set later)
+
+        Returns:
+            The new command's id, or None on failure.
+        """
+        new_id = self._next_id()
+        now = int(time.time())
+        params_json = json.dumps(params, sort_keys=True)
+        try:
+            with self._get_connection() as conn:
+                conn.execute("""
+                    INSERT INTO node_commands
+                    (id, device_id, command_type, params, status,
+                     created_at, expires_at, huey_task_id)
+                    VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)
+                """, (new_id, device_id, command_type, params_json,
+                      now, now + ttl_seconds, huey_task_id))
+                return new_id
+        except duckdb.Error as e:
+            logger.error(f"Failed to insert command: {e}")
+            return None
+
+    def set_command_huey_task(self, command_id: int, huey_task_id: str) -> bool:
+        """Backfill the huey task id after the command has been enqueued."""
+        try:
+            with self._get_connection() as conn:
+                conn.execute(
+                    "UPDATE node_commands SET huey_task_id = ? WHERE id = ?",
+                    (huey_task_id, command_id),
+                )
+            return True
+        except duckdb.Error as e:
+            logger.error(f"Failed to set huey_task_id on command {command_id}: {e}")
+            return False
+
+    def find_pending_command(self, device_id: int, command_type: str,
+                             param_filter: Optional[dict] = None) -> Optional[dict]:
+        """Find the oldest pending command for matching against a node event.
+
+        Args:
+            device_id: Device identifier
+            command_type: Command type to match
+            param_filter: Optional dict of param key→value pairs that must all
+                          match exactly. Used to distinguish e.g. valve 0 vs
+                          valve 1 commands, or curtain open vs close.
+
+        Returns:
+            Command dict (id, params, created_at, ...) or None.
+        """
+        try:
+            with self._get_connection() as conn:
+                result = conn.execute("""
+                    SELECT id, device_id, command_type, params,
+                           status, created_at, expires_at
+                    FROM node_commands
+                    WHERE device_id = ?
+                      AND command_type = ?
+                      AND status = 'pending'
+                    ORDER BY created_at ASC
+                """, (device_id, command_type))
+                for row in result.fetchall():
+                    try:
+                        row_params = json.loads(row[3])
+                    except (ValueError, TypeError):
+                        row_params = {}
+                    if param_filter:
+                        if not all(row_params.get(k) == v
+                                   for k, v in param_filter.items()):
+                            continue
+                    return {
+                        'id': row[0],
+                        'device_id': str(row[1]),
+                        'command_type': row[2],
+                        'params': row_params,
+                        'status': row[4],
+                        'created_at': row[5],
+                        'expires_at': row[6],
+                    }
+            return None
+        except duckdb.Error as e:
+            logger.error(f"Failed to find pending command: {e}")
+            return None
+
+    def update_command_status(self, command_id: int, status: str,
+                              timestamp: Optional[int] = None,
+                              event_code: Optional[int] = None,
+                              event_detail: Optional[int] = None) -> bool:
+        """Mark a command as confirmed/failed/expired/cancelled.
+
+        Args:
+            command_id: Command id
+            status: New status ('confirmed' | 'failed' | 'expired' | 'cancelled')
+            timestamp: When the transition happened (unix seconds). Defaults to
+                       now. Stored in confirmed_at for any terminal status.
+            event_code: Confirming/failing event code, for audit
+            event_detail: Confirming/failing event detail
+        """
+        ts = timestamp if timestamp is not None else int(time.time())
+        try:
+            with self._get_connection() as conn:
+                conn.execute("""
+                    UPDATE node_commands
+                    SET status = ?, confirmed_at = ?,
+                        confirming_event_code = ?,
+                        confirming_event_detail = ?
+                    WHERE id = ?
+                """, (status, ts, event_code, event_detail, command_id))
+            return True
+        except duckdb.Error as e:
+            logger.error(f"Failed to update command {command_id}: {e}")
+            return False
+
+    def query_commands(self, device_id: int,
+                       status: Optional[list[str]] = None,
+                       since: Optional[int] = None,
+                       limit: int = 100) -> list[dict]:
+        """Query commands for a device, newest first.
+
+        Args:
+            device_id: Device identifier
+            status: Optional list of statuses to include (default: all)
+            since: Earliest created_at to include (unix seconds)
+            limit: Maximum results, capped at 200
+
+        Returns:
+            List of command dicts.
+        """
+        try:
+            with self._get_connection() as conn:
+                conditions = ["device_id = ?"]
+                params: list = [device_id]
+                if status:
+                    placeholders = ", ".join("?" for _ in status)
+                    conditions.append(f"status IN ({placeholders})")
+                    params.extend(status)
+                if since is not None:
+                    conditions.append("created_at >= ?")
+                    params.append(since)
+                params.append(min(limit, 200))
+                where = " AND ".join(conditions)
+                result = conn.execute(f"""
+                    SELECT id, device_id, command_type, params, status,
+                           created_at, confirmed_at, expires_at,
+                           huey_task_id, confirming_event_code,
+                           confirming_event_detail
+                    FROM node_commands
+                    WHERE {where}
+                    ORDER BY created_at DESC
+                    LIMIT ?
+                """, params)
+                out = []
+                for row in result.fetchall():
+                    try:
+                        row_params = json.loads(row[3])
+                    except (ValueError, TypeError):
+                        row_params = {}
+                    out.append({
+                        'id': row[0],
+                        'device_id': str(row[1]),
+                        'command_type': row[2],
+                        'params': row_params,
+                        'status': row[4],
+                        'created_at': row[5],
+                        'confirmed_at': row[6],
+                        'expires_at': row[7],
+                        'huey_task_id': row[8],
+                        'confirming_event_code': row[9],
+                        'confirming_event_detail': row[10],
+                    })
+                return out
+        except duckdb.Error as e:
+            logger.error(f"Failed to query commands: {e}")
+            return []
+
+    def expire_stale_commands(self, now: Optional[int] = None) -> int:
+        """Mark any still-pending commands past their TTL as 'expired'.
+
+        Returns the number of rows updated.
+        """
+        ts = now if now is not None else int(time.time())
+        try:
+            with self._get_connection() as conn:
+                conn.execute("""
+                    UPDATE node_commands
+                    SET status = 'expired',
+                        confirmed_at = ?
+                    WHERE status = 'pending'
+                      AND expires_at < ?
+                """, (ts, ts))
+                # DuckDB doesn't expose rowcount on UPDATE reliably; query the
+                # count of just-expired rows instead.
+                result = conn.execute("""
+                    SELECT COUNT(*) FROM node_commands
+                    WHERE status = 'expired' AND confirmed_at = ?
+                """, (ts,)).fetchone()
+                return int(result[0]) if result else 0
+        except duckdb.Error as e:
+            logger.error(f"Failed to expire stale commands: {e}")
+            return 0
 
     def store_schedule(self, device_id: int, index: int, hour: int, minute: int,
                        duration: int, days: int, valve: int) -> bool:

--- a/api/serial_interface.py
+++ b/api/serial_interface.py
@@ -9,7 +9,7 @@ import logging
 
 from config import Config
 from database import SensorDatabase, SensorReading
-from event_types import EventType
+from event_types import EventType, EventCode
 
 
 logger = logging.getLogger(__name__)
@@ -470,6 +470,11 @@ class SerialInterface:
             else:
                 logger.debug(f"Duplicate event: device_id={device_id}, code=0x{event_code:04X}")
 
+            # Match pending curtain commands. EVENT_MOTOR_ERROR fails any
+            # pending curtain command; the directional/calibration events
+            # confirm the one whose action matches.
+            self._reconcile_curtain_event(device_id, event_code, timestamp)
+
         except (ValueError, IndexError) as e:
             logger.error(f"Failed to parse EVENT: {e}")
 
@@ -518,8 +523,79 @@ class SerialInterface:
                     f"severity={severity}, detail={detail}"
                 )
 
+            # Match pending ad-hoc valve commands.
+            self._reconcile_valve_event(device_id, event_type, detail, unix_ts)
+
         except (ValueError, IndexError) as e:
             logger.error(f"Failed to parse EVENT_LOG: {e}")
+
+    def _reconcile_valve_event(self, device_id: int, event_type: int,
+                               valve_id: int, unix_ts: int):
+        """Confirm pending valve commands when matching events arrive.
+
+        Matches oldest-pending-wins within (device_id, command_type, valve).
+        Ambiguous if two opens for the same valve are queued in rapid
+        succession — accepted limitation (see plan).
+        """
+        if event_type in (EventType.VALVE_OPEN, EventType.VALVE_TIMER_SET):
+            cmd_type = 'valve_open'
+        elif event_type in (EventType.VALVE_CLOSE, EventType.VALVE_TIMER_CLOSE):
+            cmd_type = 'valve_close'
+        else:
+            return
+
+        cmd = self.database.find_pending_command(
+            device_id, cmd_type, param_filter={'valve': valve_id}
+        )
+        if cmd:
+            self.database.update_command_status(
+                cmd['id'], 'confirmed', unix_ts,
+                event_code=event_type, event_detail=valve_id,
+            )
+            logger.info(
+                f"Command confirmed: id={cmd['id']}, type={cmd_type}, "
+                f"valve={valve_id}, device_id={device_id}"
+            )
+
+    def _reconcile_curtain_event(self, device_id: int, event_code: int,
+                                 unix_ts: int):
+        """Confirm or fail pending curtain commands."""
+        action_for_code = {
+            int(EventCode.EVENT_CURTAIN_OPENING): 'open',
+            int(EventCode.EVENT_CURTAIN_CLOSING): 'close',
+            int(EventCode.EVENT_CURTAIN_STOPPED): 'stop',
+            int(EventCode.EVENT_CALIBRATION_COMPLETE): 'calibrate',
+        }
+
+        if event_code == int(EventCode.EVENT_MOTOR_ERROR):
+            cmd = self.database.find_pending_command(device_id, 'curtain')
+            if cmd:
+                self.database.update_command_status(
+                    cmd['id'], 'failed', unix_ts,
+                    event_code=event_code,
+                )
+                logger.info(
+                    f"Curtain command failed (motor error): id={cmd['id']}, "
+                    f"device_id={device_id}"
+                )
+            return
+
+        action = action_for_code.get(event_code)
+        if not action:
+            return
+
+        cmd = self.database.find_pending_command(
+            device_id, 'curtain', param_filter={'action': action}
+        )
+        if cmd:
+            self.database.update_command_status(
+                cmd['id'], 'confirmed', unix_ts,
+                event_code=event_code,
+            )
+            logger.info(
+                f"Curtain command confirmed: id={cmd['id']}, action={action}, "
+                f"device_id={device_id}"
+            )
 
     def _handle_sensor_batch_start(self, line: str):
         """Handle start of sensor batch from hub.

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -8,6 +8,8 @@ import type {
   Zone,
   ZonesResponse,
   NodeEventsResponse,
+  NodeCommandsResponse,
+  NodeCommandStatus,
   IrrigationSchedulesResponse,
 } from '../types';
 
@@ -218,6 +220,24 @@ export async function getNodeEvents(
 
   const query = params.toString();
   return fetchApi<NodeEventsResponse>(`/api/nodes/${deviceId}/events${query ? `?${query}` : ''}`);
+}
+
+export async function getNodeCommands(
+  deviceId: string,
+  options?: {
+    status?: NodeCommandStatus[];
+    since?: number;
+    limit?: number;
+  }
+): Promise<NodeCommandsResponse> {
+  const params = new URLSearchParams();
+  if (options?.status?.length) params.set('status', options.status.join(','));
+  if (options?.since !== undefined) params.set('since', options.since.toString());
+  if (options?.limit !== undefined) params.set('limit', options.limit.toString());
+  const query = params.toString();
+  return fetchApi<NodeCommandsResponse>(
+    `/api/nodes/${deviceId}/commands${query ? `?${query}` : ''}`
+  );
 }
 
 // Irrigation API methods

--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type {
   Node,
   NodeEvent,
+  NodeCommand,
   NodeStatistics,
   SensorReading,
   TimeRange,
@@ -24,6 +25,7 @@ import {
   rebootNode,
   setWakeInterval,
   getNodeEvents,
+  getNodeCommands,
 } from '../api/client';
 import { NodeType } from '../types';
 import CurtainControl from './CurtainControl';
@@ -82,6 +84,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
   const [wakeIntervalStatus, setWakeIntervalStatus] = useState<string | null>(null);
   const [events, setEvents] = useState<NodeEvent[]>([]);
   const [loadingEvents, setLoadingEvents] = useState(true);
+  const [commands, setCommands] = useState<NodeCommand[]>([]);
   const [pendingEvent, setPendingEvent] = useState<PendingEvent | null>(null);
   const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -198,6 +201,18 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
     }
   }, [node.device_id]);
 
+  // Refresh the command audit log alongside events. Server response replaces
+  // local state outright — the row count is bounded by limit and the lifecycle
+  // status (pending/confirmed/...) may update in place server-side.
+  const fetchCommands = useCallback(async () => {
+    try {
+      const response = await getNodeCommands(node.device_id, { limit: 100 });
+      setCommands(response.commands);
+    } catch {
+      // Silently fail — commands log is informational
+    }
+  }, [node.device_id]);
+
   // Load older: extend backward by one window from the oldest loaded event.
   const loadOlderEvents = useCallback(async () => {
     if (loadingMoreEvents || !hasMoreEvents || events.length === 0) return;
@@ -223,9 +238,13 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
 
   useEffect(() => {
     fetchEvents();
-    const interval = setInterval(fetchEvents, REFRESH_INTERVAL_MS);
+    fetchCommands();
+    const interval = setInterval(() => {
+      fetchEvents();
+      fetchCommands();
+    }, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [fetchEvents]);
+  }, [fetchEvents, fetchCommands]);
 
   // Match incoming events against the pending event
   useEffect(() => {
@@ -252,11 +271,12 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
         status: 'pending',
       });
       fetchEvents();
+      fetchCommands();
 
       // Safety timeout — clear after 60s if never confirmed
       pendingTimeoutRef.current = setTimeout(() => setPendingEvent(null), 60000);
     },
-    [fetchEvents]
+    [fetchEvents, fetchCommands]
   );
 
   const handleMetadataUpdate = (metadata: NodeMetadata) => {
@@ -688,7 +708,13 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
           )}
 
           {node.type === NodeType.IRRIGATION && (
-            <IrrigationControl deviceId={node.device_id} onEventTriggered={fetchEvents} />
+            <IrrigationControl
+              deviceId={node.device_id}
+              onEventTriggered={() => {
+                fetchEvents();
+                fetchCommands();
+              }}
+            />
           )}
 
           {hasSensorData && (
@@ -752,6 +778,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
 
           <RecentEvents
             events={events}
+            commands={commands}
             loading={loadingEvents}
             pendingEvent={pendingEvent}
             onLoadMore={loadOlderEvents}

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -21,11 +21,13 @@ import {
   Copy,
   Check,
   Loader2,
+  XCircle,
+  Settings2,
 } from 'lucide-react';
 import { format, isToday, isYesterday } from 'date-fns';
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import type { NodeEvent } from '../types';
+import type { NodeEvent, NodeCommand, NodeCommandType } from '../types';
 import {
   getEventName,
   getEventDetail,
@@ -51,6 +53,7 @@ const PENDING_EVENT_LABELS: Record<CurtainAction, string> = {
 
 interface RecentEventsProps {
   events: NodeEvent[];
+  commands?: NodeCommand[];
   loading: boolean;
   pendingEvent?: PendingEvent | null;
   onLoadMore?: () => void;
@@ -267,6 +270,127 @@ function PendingEventIcon({ status }: { status: 'pending' | 'confirmed' }) {
   );
 }
 
+// Visual config per command type. Reuses event icons/colors so a "Valve Open"
+// command row looks consistent with the eventual "Valve Open" event row.
+const COMMAND_VISUALS: Record<NodeCommandType, EventVisual> = {
+  valve_open: EVENT_VISUALS[EventType.VALVE_OPEN] ?? DEFAULT_VISUAL,
+  valve_close: EVENT_VISUALS[EventType.VALVE_CLOSE] ?? DEFAULT_VISUAL,
+  curtain: { icon: ArrowUpFromLine, color: 'text-gray-600', bgColor: 'bg-gray-50' },
+  wake_interval: { icon: Clock, color: 'text-gray-600', bgColor: 'bg-gray-50' },
+};
+
+function curtainVisualForAction(action: string | undefined): EventVisual {
+  switch (action) {
+    case 'open':
+      return EVENT_VISUALS[EventCode.EVENT_CURTAIN_OPENING] ?? DEFAULT_VISUAL;
+    case 'close':
+      return EVENT_VISUALS[EventCode.EVENT_CURTAIN_CLOSING] ?? DEFAULT_VISUAL;
+    case 'stop':
+      return EVENT_VISUALS[EventCode.EVENT_CURTAIN_STOPPED] ?? DEFAULT_VISUAL;
+    case 'calibrate':
+      return { icon: Settings2, color: 'text-blue-600', bgColor: 'bg-blue-50' };
+    default:
+      return COMMAND_VISUALS.curtain;
+  }
+}
+
+// Human-readable label for the command row before the status suffix.
+function commandLabel(command: NodeCommand): string {
+  const params = command.params as Record<string, unknown>;
+  switch (command.command_type) {
+    case 'valve_open': {
+      const valve = typeof params.valve === 'number' ? params.valve : 0;
+      const dur = typeof params.duration_seconds === 'number'
+        ? params.duration_seconds
+        : null;
+      return dur !== null
+        ? `Valve ${valve + 1} Open · ${formatDuration(dur)}`
+        : `Valve ${valve + 1} Open`;
+    }
+    case 'valve_close': {
+      const valve = typeof params.valve === 'number' ? params.valve : 0;
+      return `Valve ${valve + 1} Close`;
+    }
+    case 'curtain': {
+      const action = typeof params.action === 'string' ? params.action : '';
+      const label =
+        action === 'open'
+          ? 'Curtain Open'
+          : action === 'close'
+            ? 'Curtain Close'
+            : action === 'stop'
+              ? 'Curtain Stop'
+              : action === 'calibrate'
+                ? 'Curtain Calibrate'
+                : `Curtain ${action}`;
+      return label;
+    }
+    case 'wake_interval': {
+      const interval = typeof params.interval_seconds === 'number'
+        ? params.interval_seconds
+        : null;
+      return interval !== null ? `Wake Interval · ${interval}s` : 'Wake Interval';
+    }
+  }
+}
+
+function commandVisual(command: NodeCommand): EventVisual {
+  if (command.command_type === 'curtain') {
+    return curtainVisualForAction(command.params.action as string | undefined);
+  }
+  return COMMAND_VISUALS[command.command_type];
+}
+
+// Suffix shown after the command label to indicate lifecycle status.
+function commandStatusSuffix(command: NodeCommand): string {
+  switch (command.status) {
+    case 'pending':
+      return ' · Pending';
+    case 'confirmed': {
+      if (command.confirmed_at) {
+        const delta = command.confirmed_at - command.created_at;
+        return delta > 0 ? ` · Confirmed · ${formatDuration(delta)}` : ' · Confirmed';
+      }
+      return ' · Confirmed';
+    }
+    case 'failed':
+      return ' · Failed';
+    case 'expired':
+      return command.command_type === 'wake_interval'
+        ? ' · Sent (no confirmation available)'
+        : ' · Expired (no response)';
+    case 'cancelled':
+      return ' · Cancelled';
+  }
+}
+
+// Status icon overlay rendered next to the row's event/command icon.
+function CommandStatusBadge({ status }: { status: NodeCommand['status'] }) {
+  if (status === 'pending') {
+    return (
+      <div className="w-6 h-6 rounded-full bg-blue-50 flex items-center justify-center">
+        <Loader2 className="w-3.5 h-3.5 animate-spin text-blue-600" />
+      </div>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <div className="w-6 h-6 rounded-full bg-red-50 flex items-center justify-center">
+        <XCircle className="w-3.5 h-3.5 text-red-600" />
+      </div>
+    );
+  }
+  if (status === 'expired' || status === 'cancelled') {
+    return (
+      <div className="w-6 h-6 rounded-full bg-gray-50 flex items-center justify-center">
+        <Clock className="w-3.5 h-3.5 text-gray-400" />
+      </div>
+    );
+  }
+  // confirmed: use the existing animated check from PendingEventIcon.
+  return <PendingEventIcon status="confirmed" />;
+}
+
 // Event codes that collapse into summary rows (per-wake-cycle noise).
 const WAKE_CYCLE_CODES = new Set<number>([EventType.WAKE, EventType.SLEEP_ENTER]);
 
@@ -300,14 +424,32 @@ function annotateDurations(events: NodeEvent[]): Map<number, number> {
   return durationByOpenTs;
 }
 
+// One row of the timeline — events (single or collapsed run of WAKE/SLEEP_ENTER)
+// or commands. Commands use their created_at as the timeline timestamp so the
+// row stays in place across pending → confirmed transitions.
+type TimelineItem =
+  | { kind: 'event'; ts: number; event: NodeEvent }
+  | { kind: 'command'; ts: number; command: NodeCommand };
+
 type RenderItem =
   | { kind: 'event'; event: NodeEvent }
+  | { kind: 'command'; command: NodeCommand }
   | {
       kind: 'collapsed';
       events: NodeEvent[]; // consecutive run of WAKE/SLEEP_ENTER
     };
 
-function collapseWakeCycles(dayEvents: NodeEvent[]): RenderItem[] {
+function mergeTimeline(events: NodeEvent[], commands: NodeCommand[]): TimelineItem[] {
+  const items: TimelineItem[] = [];
+  for (const event of events) items.push({ kind: 'event', ts: event.timestamp, event });
+  for (const command of commands) {
+    items.push({ kind: 'command', ts: command.created_at, command });
+  }
+  items.sort((a, b) => b.ts - a.ts);
+  return items;
+}
+
+function collapseWakeCycles(dayItems: TimelineItem[]): RenderItem[] {
   const items: RenderItem[] = [];
   let run: NodeEvent[] = [];
   const flush = () => {
@@ -319,12 +461,15 @@ function collapseWakeCycles(dayEvents: NodeEvent[]): RenderItem[] {
     }
     run = [];
   };
-  for (const event of dayEvents) {
-    if (WAKE_CYCLE_CODES.has(event.event_code)) {
-      run.push(event);
+  for (const item of dayItems) {
+    if (item.kind === 'event' && WAKE_CYCLE_CODES.has(item.event.event_code)) {
+      run.push(item.event);
+    } else if (item.kind === 'event') {
+      flush();
+      items.push({ kind: 'event', event: item.event });
     } else {
       flush();
-      items.push({ kind: 'event', event });
+      items.push({ kind: 'command', command: item.command });
     }
   }
   flush();
@@ -362,6 +507,7 @@ function formatCollapsedLabel(events: NodeEvent[]): string {
 
 export function RecentEvents({
   events,
+  commands,
   loading,
   pendingEvent,
   onLoadMore,
@@ -395,9 +541,12 @@ export function RecentEvents({
   // Computed once over all events so pairs spanning day boundaries still resolve.
   const durationByOpenTs = annotateDurations(filteredEvents);
 
-  const groupedEvents = filteredEvents.reduce(
-    (acc, event) => {
-      const date = new Date(event.timestamp * 1000);
+  // Merge events + commands into a single timeline, then bucket by day.
+  const timeline = mergeTimeline(filteredEvents, commands ?? []);
+
+  const groupedItems = timeline.reduce(
+    (acc, item) => {
+      const date = new Date(item.ts * 1000);
       let dayLabel: string;
       if (isToday(date)) {
         dayLabel = 'Today';
@@ -409,19 +558,19 @@ export function RecentEvents({
       if (!acc[dayLabel]) {
         acc[dayLabel] = [];
       }
-      acc[dayLabel].push(event);
+      acc[dayLabel].push(item);
       return acc;
     },
-    {} as Record<string, NodeEvent[]>
+    {} as Record<string, TimelineItem[]>
   );
 
   // Ensure "Today" group exists if we have a pending event
-  if (pendingEvent && !groupedEvents['Today']) {
-    groupedEvents['Today'] = [];
+  if (pendingEvent && !groupedItems['Today']) {
+    groupedItems['Today'] = [];
   }
 
   // Put "Today" first when we have a pending event
-  const dayEntries = Object.entries(groupedEvents);
+  const dayEntries = Object.entries(groupedItems);
   if (pendingEvent) {
     const todayIdx = dayEntries.findIndex(([day]) => day === 'Today');
     if (todayIdx > 0) {
@@ -430,11 +579,13 @@ export function RecentEvents({
     }
   }
 
+  const totalRows = events.length + (commands?.length ?? 0);
+
   return (
     <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
       <div className="px-5 py-4 border-b border-gray-200">
-        <h2 className="font-semibold text-gray-900">Recent Events</h2>
-        <p className="text-xs text-gray-500 mt-0.5">{events.length} events logged</p>
+        <h2 className="font-semibold text-gray-900">Recent Activity</h2>
+        <p className="text-xs text-gray-500 mt-0.5">{totalRows} entries</p>
       </div>
 
       {loading ? (
@@ -442,13 +593,13 @@ export function RecentEvents({
           <div className="h-4 bg-gray-200 rounded w-3/4" />
           <div className="h-4 bg-gray-200 rounded w-1/2" />
         </div>
-      ) : events.length === 0 && !pendingEvent ? (
+      ) : totalRows === 0 && !pendingEvent ? (
         <div className="px-5 py-4">
-          <p className="text-sm text-gray-400">No events recorded yet.</p>
+          <p className="text-sm text-gray-400">No activity recorded yet.</p>
         </div>
       ) : (
         <div className="px-4 py-2.5 max-h-[600px] overflow-y-auto">
-          {dayEntries.map(([day, dayEvents], dayIndex) => (
+          {dayEntries.map(([day, dayItems], dayIndex) => (
             <div key={day}>
               {dayIndex > 0 && <div className="h-px bg-gray-200 my-2.5" />}
 
@@ -469,7 +620,7 @@ export function RecentEvents({
                       <div className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md">
                         <div className="relative flex-shrink-0 mt-px">
                           <PendingEventIcon status={pendingEvent.status} />
-                          {dayEvents.length > 0 && (
+                          {dayItems.length > 0 && (
                             <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
                           )}
                         </div>
@@ -489,13 +640,55 @@ export function RecentEvents({
                 </AnimatePresence>
 
                 {(() => {
-                  const renderItems = collapseWakeCycles(dayEvents);
+                  const renderItems = collapseWakeCycles(dayItems);
                   return renderItems.map((item, index) => {
                     const adjustedIndex =
                       pendingEvent && day === 'Today' ? index + 1 : index;
                     const totalItems =
                       renderItems.length + (pendingEvent && day === 'Today' ? 1 : 0);
                     const isLast = adjustedIndex >= totalItems - 1;
+
+                    if (item.kind === 'command') {
+                      const cmd = item.command;
+                      const visual = commandVisual(cmd);
+                      const Icon = visual.icon;
+                      return (
+                        <div
+                          key={`cmd-${cmd.id}`}
+                          className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md hover:bg-gray-50 transition-colors"
+                          style={{ animationDelay: `${index * 30}ms` }}
+                        >
+                          <div className="relative flex-shrink-0 mt-px">
+                            {cmd.status === 'pending' ||
+                            cmd.status === 'failed' ||
+                            cmd.status === 'expired' ||
+                            cmd.status === 'cancelled' ? (
+                              <CommandStatusBadge status={cmd.status} />
+                            ) : (
+                              <div
+                                className={`w-6 h-6 rounded-full ${visual.bgColor} flex items-center justify-center`}
+                              >
+                                <Icon className={`w-3 h-3 ${visual.color}`} />
+                              </div>
+                            )}
+                            {!isLast && (
+                              <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2 mb-px">
+                              <span className="text-sm font-medium text-gray-900">
+                                {commandLabel(cmd)}
+                                <span className="text-gray-400">
+                                  {commandStatusSuffix(cmd)}
+                                </span>
+                              </span>
+                              <CopyableTimestamp timestamp={cmd.created_at} />
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    }
 
                     if (item.kind === 'collapsed') {
                       const first = item.events[0];

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -244,6 +244,41 @@ export interface NodeEventsResponse {
   events: NodeEvent[];
 }
 
+// Audit log entry for an ad-hoc dashboard command. Schedules are tracked in
+// the schedules table; this is for valve-run/stop, curtain, wake-interval.
+export type NodeCommandStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'failed'
+  | 'expired'
+  | 'cancelled';
+
+export type NodeCommandType =
+  | 'valve_open'
+  | 'valve_close'
+  | 'curtain'
+  | 'wake_interval';
+
+export interface NodeCommand {
+  id: number;
+  device_id: string;
+  command_type: NodeCommandType;
+  params: Record<string, unknown>;
+  status: NodeCommandStatus;
+  created_at: number;
+  confirmed_at: number | null;
+  expires_at: number;
+  huey_task_id: string | null;
+  confirming_event_code: number | null;
+  confirming_event_detail: number | null;
+}
+
+export interface NodeCommandsResponse {
+  device_id: string;
+  count: number;
+  commands: NodeCommand[];
+}
+
 // Event code display names are generated from C++ headers.
 // Regenerate with `python3 tools/gen_event_types.py`.
 import { EVENT_CODE_NAMES, EventType } from '../generated/eventTypes';


### PR DESCRIPTION
## Summary
- Adds a hub-side `node_commands` audit log so the dashboard can surface "Pending" / "Confirmed" / "Failed" / "Expired" lifecycle for ad-hoc commands (valve run/stop, curtain, wake-interval). Schedules untouched — they already have status fields.
- Closes the 30s–2min dead zone between clicking "Run 5m" and the node's `VALVE_OPEN` event arriving. Pending rows now survive page refresh.
- POST endpoints unchanged in semantics; response gains `command_id`.
- New GET `/api/nodes/<id>/commands?status=&since=&limit=`.
- `serial_interface.py` reconciles valve and curtain events against pending commands.
- `RecentEvents` renamed in-place to "Recent Activity"; renders the merged timeline.

Plan: `~/.claude/plans/yes-let-s-make-a-snazzy-simon.md` (Phase 1 of 3). Phase 2 (optimistic UI) and Phase 3 (deprecate dashboard-only curtain `PendingEvent`) are deferred.

## Test plan
- [ ] Restart API, confirm `node_commands` table created, `irrigation_schedules` unaffected.
- [ ] Click "Run 5m" on irrigation node — confirm a `Pending` row appears within one poll interval and survives a hard refresh.
- [ ] Wait for the matching `VALVE_OPEN` event — row transitions to `Confirmed · {Δs}`.
- [ ] Issue a curtain command, confirm transition on `EVENT_CURTAIN_OPENING`. Synthesise `EVENT_MOTOR_ERROR` and confirm `Failed`.
- [ ] Power-off a node, issue `wake_interval`, wait > 5 min, confirm `Sent (no confirmation available)`.
- [ ] Click "Run 5m" twice in quick succession for the same valve; confirm both rows eventually resolve.

## Notes
- Base is `feat/event-detail-display` since this builds on the new event-detail rendering; will rebase onto `main` after that PR merges.
- Confirmation matching is oldest-pending-wins (known ambiguity under rapid-fire duplicate commands; durable fix is a firmware-side `onUpdateApplied(hub_sequence)` ACK — out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)