### PR TITLE
feat(dashboard): optimistic ghost rows + drop legacy PendingEvent

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -327,11 +327,21 @@ export async function deleteIrrigationSchedule(
   });
 }
 
+// Command POST responses include `command_id` from the node_commands audit
+// log so the dashboard can correlate optimistic ghost rows with their
+// server-backed counterpart.
+interface CommandPostResponse {
+  status: string;
+  task_id: string;
+  message: string;
+  command_id: number | null;
+}
+
 export async function runValve(
   deviceId: string,
   valve: number,
   durationSeconds: number
-): Promise<{ status: string; task_id: string; message: string }> {
+): Promise<CommandPostResponse> {
   return fetchApi(`/api/nodes/${deviceId}/valve`, {
     method: 'POST',
     body: JSON.stringify({ valve, duration_seconds: durationSeconds }),
@@ -341,7 +351,7 @@ export async function runValve(
 export async function stopValve(
   deviceId: string,
   valve: number
-): Promise<{ status: string; task_id: string; message: string }> {
+): Promise<CommandPostResponse> {
   return fetchApi(`/api/nodes/${deviceId}/valve/stop`, {
     method: 'POST',
     body: JSON.stringify({ valve }),
@@ -351,7 +361,7 @@ export async function stopValve(
 export async function setWakeInterval(
   deviceId: string,
   intervalSeconds: number
-): Promise<{ status: string; task_id: string; message: string }> {
+): Promise<CommandPostResponse> {
   return fetchApi(`/api/nodes/${deviceId}/wake-interval`, {
     method: 'POST',
     body: JSON.stringify({ interval_seconds: intervalSeconds }),
@@ -361,7 +371,7 @@ export async function setWakeInterval(
 export async function controlCurtain(
   address: number,
   action: 'open' | 'close' | 'stop' | 'calibrate'
-): Promise<{ status: string; task_id: string; action: string; message: string }> {
+): Promise<CommandPostResponse & { action: string }> {
   return fetchApi(`/api/nodes/${address}/curtain`, {
     method: 'POST',
     body: JSON.stringify({ action }),

--- a/dashboard/src/components/CurtainControl.tsx
+++ b/dashboard/src/components/CurtainControl.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Zap, ChevronUp, ChevronDown, Square, Check, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { controlCurtain } from '../api/client';
 
 export type CurtainAction = 'open' | 'close' | 'stop';
 type CurtainActionState = 'idle' | 'sending' | 'queued' | 'error';
@@ -14,10 +13,10 @@ interface ButtonState {
 
 interface CurtainControlProps {
   address: number;
-  onCommandQueued?: (action: CurtainAction) => void;
+  issueCurtain: (action: CurtainAction, address: number) => Promise<void>;
 }
 
-function CurtainControl({ address, onCommandQueued }: CurtainControlProps) {
+function CurtainControl({ address, issueCurtain }: CurtainControlProps) {
   const [buttonState, setButtonState] = useState<ButtonState>({ state: 'idle' });
 
   const dismissError = useCallback(() => {
@@ -27,11 +26,10 @@ function CurtainControl({ address, onCommandQueued }: CurtainControlProps) {
   const handleAction = async (action: CurtainAction) => {
     setButtonState({ state: 'sending', action });
     try {
-      await controlCurtain(address, action);
+      await issueCurtain(action, address);
       setButtonState({ state: 'queued', action });
       setTimeout(() => {
         setButtonState((prev) => (prev.state === 'queued' ? { state: 'idle' } : prev));
-        onCommandQueued?.(action);
       }, 2000);
     } catch (err) {
       setButtonState({

--- a/dashboard/src/components/IrrigationControl.tsx
+++ b/dashboard/src/components/IrrigationControl.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { Zap, Play, Square, Check, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
-  runValve,
-  stopValve,
   getIrrigationSchedules,
   addIrrigationSchedule,
   deleteIrrigationSchedule,
@@ -23,7 +21,8 @@ interface ValveState {
 
 interface IrrigationControlProps {
   deviceId: string;
-  onEventTriggered?: () => void;
+  issueRunValve: (valve: number, durationSeconds: number) => Promise<void>;
+  issueStopValve: (valve: number) => Promise<void>;
 }
 
 // Non-linear notches: fine-grained at short durations, coarser for long runs
@@ -49,7 +48,7 @@ function formatDurationShort(minutes: number): string {
   return `${minutes}m`;
 }
 
-function IrrigationControl({ deviceId, onEventTriggered }: IrrigationControlProps) {
+function IrrigationControl({ deviceId, issueRunValve, issueStopValve }: IrrigationControlProps) {
   // Run-once state
   const [selectedDuration, setSelectedDuration] = useState<Record<number, number>>({
     0: 300,
@@ -100,11 +99,11 @@ function IrrigationControl({ deviceId, onEventTriggered }: IrrigationControlProp
     setValveState(valve, { state: 'sending', action: 'run' });
     try {
       const duration = selectedDuration[valve] || 300;
-      await runValve(deviceId, valve, duration);
+      await issueRunValve(valve, duration);
+      // The hook inserts an optimistic row in the activity log immediately;
+      // we just need the button-level "Queued" affordance to confirm to the
+      // user that the click landed.
       setValveState(valve, { state: 'queued', action: 'run' });
-      // Refresh events soon to pick up Valve Open / Valve Timer Set.
-      if (onEventTriggered) setTimeout(onEventTriggered, 3000);
-      // Return to idle after the Queued checkmark has been visible.
       setTimeout(() => {
         setValveStates((prev) =>
           prev[valve].state === 'queued' ? { ...prev, [valve]: { state: 'idle' } } : prev
@@ -122,9 +121,8 @@ function IrrigationControl({ deviceId, onEventTriggered }: IrrigationControlProp
   const handleStop = async (valve: number) => {
     setValveState(valve, { state: 'sending', action: 'stop' });
     try {
-      await stopValve(deviceId, valve);
+      await issueStopValve(valve);
       setValveState(valve, { state: 'idle' });
-      if (onEventTriggered) setTimeout(onEventTriggered, 3000);
     } catch (err) {
       setValveState(valve, {
         state: 'error',

--- a/dashboard/src/components/NodeDetail.tsx
+++ b/dashboard/src/components/NodeDetail.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type {
   Node,
   NodeEvent,
-  NodeCommand,
   NodeStatistics,
   SensorReading,
   TimeRange,
@@ -23,13 +22,10 @@ import {
   getNodeStatistics,
   deleteNode,
   rebootNode,
-  setWakeInterval,
   getNodeEvents,
-  getNodeCommands,
 } from '../api/client';
 import { NodeType } from '../types';
 import CurtainControl from './CurtainControl';
-import type { CurtainAction } from './CurtainControl';
 import IrrigationControl from './IrrigationControl';
 import NodeNameEditor from './NodeNameEditor';
 import SensorChart from './SensorChart';
@@ -40,15 +36,8 @@ import SignalStrength from './SignalStrength';
 import HealthStatus from './HealthStatus';
 import BacklogStatus from './BacklogStatus';
 import { RecentEvents } from './RecentEvents';
-import type { PendingEvent } from './RecentEvents';
 import { REFRESH_INTERVAL_MS } from '../config';
-import { EventCode } from '../types';
-
-const ACTION_TO_EVENT_CODE: Record<CurtainAction, number> = {
-  open: EventCode.EVENT_CURTAIN_OPENING,
-  close: EventCode.EVENT_CURTAIN_CLOSING,
-  stop: EventCode.EVENT_CURTAIN_STOPPED,
-};
+import { useNodeCommands } from '../hooks/useNodeCommands';
 
 interface NodeDetailProps {
   node: Node;
@@ -84,9 +73,13 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
   const [wakeIntervalStatus, setWakeIntervalStatus] = useState<string | null>(null);
   const [events, setEvents] = useState<NodeEvent[]>([]);
   const [loadingEvents, setLoadingEvents] = useState(true);
-  const [commands, setCommands] = useState<NodeCommand[]>([]);
-  const [pendingEvent, setPendingEvent] = useState<PendingEvent | null>(null);
-  const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const {
+    commands,
+    issueRunValve,
+    issueStopValve,
+    issueCurtain,
+    issueSetWakeInterval,
+  } = useNodeCommands(node.device_id);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const hasSensorData = node.type === NodeType.SENSOR || node.type === NodeType.GREENHOUSE;
@@ -201,18 +194,6 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
     }
   }, [node.device_id]);
 
-  // Refresh the command audit log alongside events. Server response replaces
-  // local state outright — the row count is bounded by limit and the lifecycle
-  // status (pending/confirmed/...) may update in place server-side.
-  const fetchCommands = useCallback(async () => {
-    try {
-      const response = await getNodeCommands(node.device_id, { limit: 100 });
-      setCommands(response.commands);
-    } catch {
-      // Silently fail — commands log is informational
-    }
-  }, [node.device_id]);
-
   // Load older: extend backward by one window from the oldest loaded event.
   const loadOlderEvents = useCallback(async () => {
     if (loadingMoreEvents || !hasMoreEvents || events.length === 0) return;
@@ -238,46 +219,9 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
 
   useEffect(() => {
     fetchEvents();
-    fetchCommands();
-    const interval = setInterval(() => {
-      fetchEvents();
-      fetchCommands();
-    }, REFRESH_INTERVAL_MS);
+    const interval = setInterval(fetchEvents, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [fetchEvents, fetchCommands]);
-
-  // Match incoming events against the pending event
-  useEffect(() => {
-    if (!pendingEvent || pendingEvent.status !== 'pending') return;
-    const match = events.find(
-      (e) =>
-        e.event_code === pendingEvent.expectedEventCode && e.timestamp >= pendingEvent.createdAt - 5
-    );
-    if (match) {
-      setPendingEvent((prev) => (prev ? { ...prev, status: 'confirmed' } : null));
-      setTimeout(() => setPendingEvent(null), 3000);
-    }
-  }, [events, pendingEvent]);
-
-  const handleCommandQueued = useCallback(
-    (action: CurtainAction) => {
-      // Clear any previous safety timeout
-      if (pendingTimeoutRef.current) clearTimeout(pendingTimeoutRef.current);
-
-      setPendingEvent({
-        action,
-        expectedEventCode: ACTION_TO_EVENT_CODE[action],
-        createdAt: Math.floor(Date.now() / 1000),
-        status: 'pending',
-      });
-      fetchEvents();
-      fetchCommands();
-
-      // Safety timeout — clear after 60s if never confirmed
-      pendingTimeoutRef.current = setTimeout(() => setPendingEvent(null), 60000);
-    },
-    [fetchEvents, fetchCommands]
-  );
+  }, [fetchEvents]);
 
   const handleMetadataUpdate = (metadata: NodeMetadata) => {
     onUpdate({
@@ -321,7 +265,7 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
     setSettingWakeInterval(true);
     setWakeIntervalStatus(null);
     try {
-      await setWakeInterval(node.device_id, Math.round(minutes * 60));
+      await issueSetWakeInterval(Math.round(minutes * 60));
       setWakeIntervalStatus('Queued successfully');
     } catch (err) {
       setWakeIntervalStatus(err instanceof Error ? err.message : 'Failed to set wake interval');
@@ -704,16 +648,14 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
         {/* Controls column — renders first on mobile */}
         <div className="lg:col-span-2 space-y-4 order-first lg:order-none">
           {node.type === NodeType.GREENHOUSE && (
-            <CurtainControl address={node.address} onCommandQueued={handleCommandQueued} />
+            <CurtainControl address={node.address} issueCurtain={issueCurtain} />
           )}
 
           {node.type === NodeType.IRRIGATION && (
             <IrrigationControl
               deviceId={node.device_id}
-              onEventTriggered={() => {
-                fetchEvents();
-                fetchCommands();
-              }}
+              issueRunValve={issueRunValve}
+              issueStopValve={issueStopValve}
             />
           )}
 
@@ -780,7 +722,6 @@ function NodeDetail({ node, zones, onBack, onUpdate, onDelete, onZoneCreated }: 
             events={events}
             commands={commands}
             loading={loadingEvents}
-            pendingEvent={pendingEvent}
             onLoadMore={loadOlderEvents}
             hasMore={hasMoreEvents}
             loadingMore={loadingMoreEvents}

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -36,26 +36,11 @@ import {
   EventType,
   EventCode,
 } from '../types';
-import type { CurtainAction } from './CurtainControl';
-
-export interface PendingEvent {
-  action: CurtainAction;
-  expectedEventCode: number;
-  createdAt: number;
-  status: 'pending' | 'confirmed';
-}
-
-const PENDING_EVENT_LABELS: Record<CurtainAction, string> = {
-  open: 'Curtain Open',
-  close: 'Curtain Close',
-  stop: 'Curtain Stop',
-};
 
 interface RecentEventsProps {
   events: NodeEvent[];
   commands?: NodeCommand[];
   loading: boolean;
-  pendingEvent?: PendingEvent | null;
   onLoadMore?: () => void;
   hasMore?: boolean;
   loadingMore?: boolean;
@@ -509,7 +494,6 @@ export function RecentEvents({
   events,
   commands,
   loading,
-  pendingEvent,
   onLoadMore,
   hasMore,
   loadingMore,
@@ -527,22 +511,11 @@ export function RecentEvents({
     });
   };
 
-  // Filter out the real event that matches the pending one to avoid duplicates
-  const filteredEvents = pendingEvent
-    ? events.filter(
-        (e) =>
-          !(
-            e.event_code === pendingEvent.expectedEventCode &&
-            e.timestamp >= pendingEvent.createdAt - 5
-          )
-      )
-    : events;
-
   // Computed once over all events so pairs spanning day boundaries still resolve.
-  const durationByOpenTs = annotateDurations(filteredEvents);
+  const durationByOpenTs = annotateDurations(events);
 
   // Merge events + commands into a single timeline, then bucket by day.
-  const timeline = mergeTimeline(filteredEvents, commands ?? []);
+  const timeline = mergeTimeline(events, commands ?? []);
 
   const groupedItems = timeline.reduce(
     (acc, item) => {
@@ -564,21 +537,7 @@ export function RecentEvents({
     {} as Record<string, TimelineItem[]>
   );
 
-  // Ensure "Today" group exists if we have a pending event
-  if (pendingEvent && !groupedItems['Today']) {
-    groupedItems['Today'] = [];
-  }
-
-  // Put "Today" first when we have a pending event
   const dayEntries = Object.entries(groupedItems);
-  if (pendingEvent) {
-    const todayIdx = dayEntries.findIndex(([day]) => day === 'Today');
-    if (todayIdx > 0) {
-      const [todayEntry] = dayEntries.splice(todayIdx, 1);
-      dayEntries.unshift(todayEntry);
-    }
-  }
-
   const totalRows = events.length + (commands?.length ?? 0);
 
   return (
@@ -593,7 +552,7 @@ export function RecentEvents({
           <div className="h-4 bg-gray-200 rounded w-3/4" />
           <div className="h-4 bg-gray-200 rounded w-1/2" />
         </div>
-      ) : totalRows === 0 && !pendingEvent ? (
+      ) : totalRows === 0 ? (
         <div className="px-5 py-4">
           <p className="text-sm text-gray-400">No activity recorded yet.</p>
         </div>
@@ -606,47 +565,10 @@ export function RecentEvents({
               <div className="text-xs font-medium text-gray-500 mb-1.5 px-1">{day}</div>
 
               <div>
-                {/* Pending event row — always first in "Today" */}
-                <AnimatePresence>
-                  {pendingEvent && day === 'Today' && (
-                    <motion.div
-                      key="pending-event"
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
-                      transition={{ duration: 0.25 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="event-item group relative flex items-start gap-2.5 py-1.5 px-1.5 rounded-md">
-                        <div className="relative flex-shrink-0 mt-px">
-                          <PendingEventIcon status={pendingEvent.status} />
-                          {dayItems.length > 0 && (
-                            <div className="absolute top-7 left-1/2 -translate-x-px w-px h-2.5 bg-gray-200" />
-                          )}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-start justify-between gap-2 mb-px">
-                            <span className="text-sm font-medium text-gray-900">
-                              {PENDING_EVENT_LABELS[pendingEvent.action]}
-                            </span>
-                            <span className="text-xs text-gray-400">
-                              {pendingEvent.status === 'pending' ? 'Pending...' : 'Confirmed'}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-
                 {(() => {
                   const renderItems = collapseWakeCycles(dayItems);
                   return renderItems.map((item, index) => {
-                    const adjustedIndex =
-                      pendingEvent && day === 'Today' ? index + 1 : index;
-                    const totalItems =
-                      renderItems.length + (pendingEvent && day === 'Today' ? 1 : 0);
-                    const isLast = adjustedIndex >= totalItems - 1;
+                    const isLast = index >= renderItems.length - 1;
 
                     if (item.kind === 'command') {
                       const cmd = item.command;

--- a/dashboard/src/hooks/useNodeCommands.ts
+++ b/dashboard/src/hooks/useNodeCommands.ts
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { NodeCommand } from '../types';
+import {
+  getNodeCommands,
+  runValve,
+  stopValve,
+  controlCurtain,
+  setWakeInterval,
+} from '../api/client';
+import type { CurtainAction } from '../components/CurtainControl';
+import { REFRESH_INTERVAL_MS } from '../config';
+
+// Server-side default TTLs from api/command_queue.py — used only to give the
+// optimistic ghost row a plausible `expires_at` until the server row replaces
+// it. The real TTL is enforced server-side regardless.
+const OPTIMISTIC_TTL_SECONDS: Record<NodeCommand['command_type'], number> = {
+  valve_open: 1800,
+  valve_close: 1800,
+  curtain: 600,
+  wake_interval: 300,
+};
+
+interface OptimisticCommand extends NodeCommand {
+  tempKey: string;
+  // Set once the POST returns; until then we render the ghost row,
+  // after which the next server poll replaces it.
+  serverId?: number;
+}
+
+function makeTempKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function buildOptimistic(
+  deviceId: string,
+  commandType: NodeCommand['command_type'],
+  params: Record<string, unknown>
+): OptimisticCommand {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: -1,
+    tempKey: makeTempKey(),
+    device_id: deviceId,
+    command_type: commandType,
+    params,
+    status: 'pending',
+    created_at: now,
+    confirmed_at: null,
+    expires_at: now + OPTIMISTIC_TTL_SECONDS[commandType],
+    huey_task_id: null,
+    confirming_event_code: null,
+    confirming_event_detail: null,
+  };
+}
+
+export interface UseNodeCommands {
+  commands: NodeCommand[];
+  refresh: () => Promise<void>;
+  issueRunValve: (valve: number, durationSeconds: number) => Promise<void>;
+  issueStopValve: (valve: number) => Promise<void>;
+  issueCurtain: (action: CurtainAction, address: number) => Promise<void>;
+  issueSetWakeInterval: (intervalSeconds: number) => Promise<void>;
+}
+
+export function useNodeCommands(deviceId: string): UseNodeCommands {
+  const [serverCommands, setServerCommands] = useState<NodeCommand[]>([]);
+  const [optimistic, setOptimistic] = useState<OptimisticCommand[]>([]);
+  // Avoid double-refresh races if the hook unmounts mid-fetch.
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const resp = await getNodeCommands(deviceId, { limit: 100 });
+      if (aliveRef.current) {
+        setServerCommands(resp.commands);
+      }
+    } catch {
+      // Silently fail — commands log is informational
+    }
+  }, [deviceId]);
+
+  // Initial fetch + poll loop.
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  // Wrap a POST in optimistic state. On success, tag the ghost with the
+  // returned server command_id (next poll's response will replace it). On
+  // failure, mark it as failed and auto-clear after 5s.
+  const wrap = useCallback(
+    async (
+      ghost: OptimisticCommand,
+      send: () => Promise<{ command_id?: number | null }>
+    ) => {
+      setOptimistic((o) => [ghost, ...o]);
+      try {
+        const resp = await send();
+        const serverId = typeof resp.command_id === 'number' ? resp.command_id : undefined;
+        setOptimistic((o) =>
+          o.map((x) =>
+            x.tempKey === ghost.tempKey
+              ? { ...x, serverId, id: serverId ?? x.id }
+              : x
+          )
+        );
+        // Pull the canonical row right away so the merge can drop the ghost.
+        refresh();
+      } catch (err) {
+        setOptimistic((o) =>
+          o.map((x) =>
+            x.tempKey === ghost.tempKey ? { ...x, status: 'failed' } : x
+          )
+        );
+        setTimeout(() => {
+          if (!aliveRef.current) return;
+          setOptimistic((o) => o.filter((x) => x.tempKey !== ghost.tempKey));
+        }, 5000);
+        throw err;
+      }
+    },
+    [refresh]
+  );
+
+  const issueRunValve = useCallback(
+    (valve: number, durationSeconds: number) =>
+      wrap(
+        buildOptimistic(deviceId, 'valve_open', {
+          valve,
+          duration_seconds: durationSeconds,
+        }),
+        () => runValve(deviceId, valve, durationSeconds)
+      ),
+    [deviceId, wrap]
+  );
+
+  const issueStopValve = useCallback(
+    (valve: number) =>
+      wrap(
+        buildOptimistic(deviceId, 'valve_close', { valve }),
+        () => stopValve(deviceId, valve)
+      ),
+    [deviceId, wrap]
+  );
+
+  const issueCurtain = useCallback(
+    (action: CurtainAction, address: number) =>
+      wrap(
+        buildOptimistic(deviceId, 'curtain', { action }),
+        () => controlCurtain(address, action)
+      ),
+    [deviceId, wrap]
+  );
+
+  const issueSetWakeInterval = useCallback(
+    (intervalSeconds: number) =>
+      wrap(
+        buildOptimistic(deviceId, 'wake_interval', {
+          interval_seconds: intervalSeconds,
+        }),
+        () => setWakeInterval(deviceId, intervalSeconds)
+      ),
+    [deviceId, wrap]
+  );
+
+  // Merge: server data wins. Ghost rows are visible until their serverId
+  // shows up in serverCommands (or the POST resolved with no command_id,
+  // in which case they live until manually cleared / failed).
+  const commands = useMemo<NodeCommand[]>(() => {
+    const serverIds = new Set(serverCommands.map((c) => c.id));
+    const visibleOptimistic = optimistic.filter(
+      (o) => o.serverId === undefined || !serverIds.has(o.serverId)
+    );
+    return [...serverCommands, ...visibleOptimistic].sort(
+      (a, b) => b.created_at - a.created_at
+    );
+  }, [serverCommands, optimistic]);
+
+  return {
+    commands,
+    refresh,
+    issueRunValve,
+    issueStopValve,
+    issueCurtain,
+    issueSetWakeInterval,
+  };
+}


### PR DESCRIPTION
Re-baseline of the original PR #180. Stacked on #181 (\`feat/commands-audit-log\`). After #181 merges, this rebases onto \`main\` cleanly.

## Summary
- New \`useNodeCommands\` hook (\`dashboard/src/hooks/useNodeCommands.ts\`) owns activity-log polling + per-click optimistic state.
- \`issueRunValve\`, \`issueStopValve\`, \`issueCurtain\`, \`issueSetWakeInterval\` each insert a ghost \`NodeCommand\` row at click time and replace it with the server-backed row (matched by \`command_id\`) once the POST returns.
- POST failure → ghost flips to \`failed\`, auto-clears in 5s. Server-side TTL is the source of truth for "still pending".
- Phase 3 cleanup: deleted the curtain-only \`PendingEvent\` machinery in \`NodeDetail.tsx\` and \`RecentEvents.tsx\`. All four command paths now flow through the hook → activity log.

Net diff: **+241 / -174** lines.

## Test plan
- [ ] Click "Run 5m" — ghost row visible within an animation frame (<100ms).
- [ ] POST resolves → no visible flicker; next poll replaces the ghost transparently.
- [ ] Matching \`VALVE_OPEN\` event → row transitions to \`Confirmed · {Δs}\`.
- [ ] Kill API container → ghost flips to \`Failed\` → disappears in 5s.
- [ ] Hard-refresh during pending — row reappears from server within one poll cycle.
- [ ] Click "Run 5m" 3× in <500ms — three distinct rows, each resolves independently.
- [ ] Curtain commands now flow through the hook; \`EVENT_MOTOR_ERROR\` → \`Failed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)