### PR TITLE
feat(boards): add bramble v5 hardware variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,18 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-# Board revision: V3 (RP2040, Adafruit Feather) or V4 (RP2350B, custom PCB)
-set(BOARD_VERSION "V3" CACHE STRING "Board revision: V3 (RP2040) or V4 (RP2350B)")
-set_property(CACHE BOARD_VERSION PROPERTY STRINGS V3 V4)
+# Board revision: V3 (RP2040, Adafruit Feather), V4 (RP2350B custom PCB), V5 (RP2350B revised)
+set(BOARD_VERSION "V3" CACHE STRING "Board revision: V3 (RP2040), V4 or V5 (RP2350B)")
+set_property(CACHE BOARD_VERSION PROPERTY STRINGS V3 V4 V5)
 string(TOUPPER "${BOARD_VERSION}" BOARD_VERSION)
 
-if(BOARD_VERSION STREQUAL "V4")
+if(BOARD_VERSION STREQUAL "V5")
+    set(PICO_BOARD bramble_v5 CACHE STRING "Board type" FORCE)
+    set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/boards CACHE STRING "" FORCE)
+    set(PICO_PLATFORM rp2350-arm-s CACHE STRING "Platform" FORCE)
+    unset(PICO_DEFAULT_BOOT_STAGE2_FILE CACHE)
+    message(STATUS "Board version: V5 (RP2350B)")
+elseif(BOARD_VERSION STREQUAL "V4")
     set(PICO_BOARD bramble_v4 CACHE STRING "Board type" FORCE)
     set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/boards CACHE STRING "" FORCE)
     set(PICO_PLATFORM rp2350-arm-s CACHE STRING "Platform" FORCE)
@@ -161,7 +167,9 @@ else()
     message(STATUS "Radio chip: ${RADIO_CHIP} (${RADIO_SOURCE})")
 
     # Board suffix for executable names (e.g. bramble_sensor_v4_sx1262)
-    if(BOARD_VERSION STREQUAL "V4")
+    if(BOARD_VERSION STREQUAL "V5")
+        set(BOARD_SUFFIX "_v5")
+    elseif(BOARD_VERSION STREQUAL "V4")
         set(BOARD_SUFFIX "_v4")
     else()
         set(BOARD_SUFFIX "")
@@ -335,7 +343,17 @@ if(NOT BUILD_TESTS)
         endif()
 
         # Board-specific configuration
-        if(BOARD_VERSION STREQUAL "V4")
+        if(BOARD_VERSION STREQUAL "V5")
+            # V5: SDK board header (bramble_v5.h) sets UART0/GPIO28/29 defaults
+            target_compile_definitions(${TARGET_NAME} PRIVATE
+                BOARD_V5=1
+                PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
+                PICO_STACK_SIZE=0x1000
+                BRAMBLE_VERSION_MAJOR=${BRAMBLE_VERSION_MAJOR}
+                BRAMBLE_VERSION_MINOR=${BRAMBLE_VERSION_MINOR}
+                BRAMBLE_VERSION_BUILD=${BRAMBLE_VERSION_BUILD}
+            )
+        elseif(BOARD_VERSION STREQUAL "V4")
             # V4: SDK board header (bramble_v4.h) sets UART0/GPIO28/29 defaults
             target_compile_definitions(${TARGET_NAME} PRIVATE
                 BOARD_V4=1
@@ -384,8 +402,8 @@ if(NOT BUILD_TESTS)
             pico_unique_id
         )
 
-        # RTC: RP2040 uses hardware_rtc, RP2350 uses pico_aon_timer
-        if(BOARD_VERSION STREQUAL "V4")
+        # RTC: RP2040 uses hardware_rtc, RP2350 (V4/V5) uses pico_aon_timer
+        if(BOARD_VERSION STREQUAL "V5" OR BOARD_VERSION STREQUAL "V4")
             target_link_libraries(${TARGET_NAME} pico_aon_timer)
         else()
             target_link_libraries(${TARGET_NAME} hardware_rtc)

--- a/boards/bramble_v5.h
+++ b/boards/bramble_v5.h
@@ -1,0 +1,61 @@
+/**
+ * @file bramble_v5.h
+ * @brief Pico SDK board definition for Bramble v5 (custom RP2350B board)
+ *
+ * v5 fixes v4 PCB defects: native LoRa SPI mux, native SX1262 DIO1/BUSY,
+ * native UART1 RX on GPIO9. Same chip + flash + headers as v4.
+ *
+ * Referenced by the SDK via PICO_BOARD and PICO_BOARD_HEADER_DIRS.
+ */
+
+#ifndef _BOARDS_BRAMBLE_V5_H
+#define _BOARDS_BRAMBLE_V5_H
+
+// --- Chip variant ---
+// RP2350B has 48 GPIOs (vs 30 on standard RP2350A)
+#ifndef PICO_RP2350A
+#define PICO_RP2350A 0
+#endif
+
+// --- Flash ---
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+
+// --- Crystal ---
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
+// --- UART defaults ---
+// Stdio on UART0 GPIO28/29 (J6 header pins 10/9)
+// PMU uses UART1 on GPIO8/9 — no peripheral conflict
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 28
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 29
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 4
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 4
+#endif
+
+// --- Board identification ---
+#define BRAMBLE_V5_BOARD 1
+
+#endif  // _BOARDS_BRAMBLE_V5_H

--- a/main.cpp
+++ b/main.cpp
@@ -65,11 +65,16 @@
 #include "modes/application_mode.h"
 #endif
 
-#ifdef BOARD_V4
+#if defined(BOARD_V4) || defined(BOARD_V5)
 #include "board/board_pins.h"
+#ifdef BOARD_V4
 #include "hal/bitbang_spi_device.h"
+#else
+#include "hal/spi_device.h"
+#endif
 
-// V4: LoRa on bit-bang SPI (MOSI/SCK swapped on PCB vs RP2350 pin mux)
+// V4/V5: shared RP2350B layout — pins come from Board:: namespace.
+// V4 uses bit-bang SPI (MOSI/SCK swapped on PCB); V5 uses hardware SPI1.
 constexpr uint PIN_MISO = Board::LORA_PIN_MISO;
 constexpr uint PIN_MOSI = Board::LORA_PIN_MOSI;
 constexpr uint PIN_SCK = Board::LORA_PIN_SCK;
@@ -102,7 +107,7 @@ constexpr uint PIN_NEOPIXEL = 4;
 // Controller input pins (Adafruit Feather RP2040)
 constexpr uint PIN_A0 = 26;  // A0 analog/digital input
 constexpr uint PIN_A1 = 27;  // A1 analog/digital input
-#endif  // BOARD_V4
+#endif  // BOARD_V4 / BOARD_V5
 
 // Demo mode configuration is set by CMake
 // Debug UART: printf goes to GPIO12 (VALVE_3) via CMakeLists.txt config
@@ -225,6 +230,9 @@ int main()
 #ifdef BOARD_V4
     // V4: bit-bang SPI (MOSI/SCK swapped on PCB)
     BitBangSPIDevice lora_spi(PIN_MOSI, PIN_MISO, PIN_SCK, PIN_CS);
+#elif defined(BOARD_V5)
+    // V5: hardware SPI1 (MOSI/SCK routing fixed in PCB)
+    SPIDevice lora_spi(Board::LORA_SPI_PORT, PIN_CS);
 #else
     // V3: hardware SPI
     SPIDevice lora_spi(SPI_PORT, PIN_CS);
@@ -409,8 +417,8 @@ bool initializeHardware(RadioInterface &lora, NeoPixel &led)
 {
     Logger log("Hardware");
 
-#ifdef BOARD_V4
-    // V4: LoRa uses bit-bang SPI (pins configured by BitBangSPIDevice constructor)
+#if defined(BOARD_V4) || defined(BOARD_V5)
+    // V4/V5: external flash on dedicated SPI0 (LoRa is on SPI1 / bit-bang)
 
     // Deselect external flash CS and deassert RST BEFORE SPI init.
     // CS can float low on power-up, causing the flash to respond to
@@ -428,6 +436,19 @@ bool initializeHardware(RadioInterface &lora, NeoPixel &led)
     gpio_set_function(Board::FLASH_PIN_MISO, GPIO_FUNC_SPI);
     gpio_set_function(Board::FLASH_PIN_SCK, GPIO_FUNC_SPI);
     gpio_set_function(Board::FLASH_PIN_MOSI, GPIO_FUNC_SPI);
+
+#ifdef BOARD_V5
+    // V5: LoRa on hardware SPI1 — pin mux MISO/SCK/MOSI here.
+    // CS is software-controlled (kept as SIO), driven high before any SPI traffic.
+    gpio_init(Board::LORA_PIN_CS);
+    gpio_put(Board::LORA_PIN_CS, 1);
+    gpio_set_dir(Board::LORA_PIN_CS, GPIO_OUT);
+
+    spi_init(Board::LORA_SPI_PORT, 1000 * 1000);
+    gpio_set_function(Board::LORA_PIN_MISO, GPIO_FUNC_SPI);
+    gpio_set_function(Board::LORA_PIN_SCK, GPIO_FUNC_SPI);
+    gpio_set_function(Board::LORA_PIN_MOSI, GPIO_FUNC_SPI);
+#endif
 #else
     // V3: SPI1 shared by LoRa + flash
     spi_init(SPI_PORT, 1000 * 1000);

--- a/src/board/board_pins.h
+++ b/src/board/board_pins.h
@@ -4,11 +4,13 @@
  * @file board_pins.h
  * @brief Board pin configuration selector
  *
- * Includes the correct pin header based on BOARD_V4 compile definition.
+ * Selects the pin header based on BOARD_V5 / BOARD_V4 compile definitions.
  * Default is v3 (Adafruit Feather RP2040 RFM9x).
  */
 
-#if defined(BOARD_V4)
+#if defined(BOARD_V5)
+#include "bramble_v5_pins.h"
+#elif defined(BOARD_V4)
 #include "bramble_v4_pins.h"
 #else
 #include "bramble_v3_pins.h"

--- a/src/board/bramble_v5_pins.h
+++ b/src/board/bramble_v5_pins.h
@@ -1,0 +1,129 @@
+#pragma once
+
+/**
+ * @file bramble_v5_pins.h
+ * @brief Pin definitions for Bramble v5 board (custom RP2350B)
+ *
+ * v5 fixes the v4 PCB wiring defects:
+ *   - LoRa MOSI/SCK no longer swapped — hardware SPI1 works directly
+ *   - SX1262 DIO1 / BUSY routed natively (no bodge wires)
+ *   - PMU UART RX on GPIO9 functional (no bodge to GPIO21)
+ */
+
+#include "hardware/i2c.h"
+#include "hardware/spi.h"
+#include "hardware/uart.h"
+
+namespace Board {
+
+// ==========================================================================
+// Physical header definitions (GPIO numbers for each connector pin)
+// Pin 1 = +3V3, Pin 2 = +9V, Pin 11 = VDD, Pin 12 = GND on all headers
+// ==========================================================================
+
+namespace J6 {                  // Motor/Valve connector (GPIO 28-35)
+constexpr uint8_t PIN_3 = 35;   // VALVE_3
+constexpr uint8_t PIN_4 = 34;   // MOTOR_LO_2
+constexpr uint8_t PIN_5 = 33;   // VALVE_4
+constexpr uint8_t PIN_6 = 32;   // MOTOR_LO_1
+constexpr uint8_t PIN_7 = 31;   // VALVE_2
+constexpr uint8_t PIN_8 = 30;   // MOTOR_HI_2
+constexpr uint8_t PIN_9 = 29;   // VALVE_1
+constexpr uint8_t PIN_10 = 28;  // MOTOR_HI_1
+}  // namespace J6
+
+namespace J7 {  // GPIO/debug header (GPIO 36-43)
+constexpr uint8_t PIN_3 = 43;
+constexpr uint8_t PIN_4 = 42;
+constexpr uint8_t PIN_5 = 41;
+constexpr uint8_t PIN_6 = 40;
+constexpr uint8_t PIN_7 = 39;
+constexpr uint8_t PIN_8 = 38;
+constexpr uint8_t PIN_9 = 37;
+constexpr uint8_t PIN_10 = 36;
+}  // namespace J7
+
+namespace J8 {  // General purpose header (GPIO 20-27)
+constexpr uint8_t PIN_3 = 26;
+constexpr uint8_t PIN_4 = 27;
+constexpr uint8_t PIN_5 = 24;
+constexpr uint8_t PIN_6 = 25;
+constexpr uint8_t PIN_7 = 22;
+constexpr uint8_t PIN_8 = 23;
+constexpr uint8_t PIN_9 = 20;
+constexpr uint8_t PIN_10 = 21;
+}  // namespace J8
+
+// ==========================================================================
+// Functional pin assignments
+// ==========================================================================
+
+// --- LoRa (SX1262 / NiceRF LORA1262 on hardware SPI1) ---
+// v5: PCB routes MOSI to GPIO15 and SCK to GPIO14 — matches SPI1 pin mux,
+// so hardware SPI works directly (no bit-bang needed unlike v4).
+inline auto LORA_SPI_PORT = spi1;
+constexpr uint LORA_PIN_MISO = 12;  // SPI1 RX
+constexpr uint LORA_PIN_SCK = 14;   // SPI1 SCK
+constexpr uint LORA_PIN_MOSI = 15;  // SPI1 TX
+constexpr uint LORA_PIN_CS = 10;    // GPIO chip-select (not hardware CSn)
+constexpr uint LORA_PIN_RST = 16;
+constexpr uint LORA_PIN_DIO1 = 19;
+constexpr uint LORA_PIN_BUSY = 18;
+
+// --- External flash (dedicated SPI0) ---
+constexpr bool FLASH_HAS_DEDICATED_SPI = true;
+inline auto FLASH_SPI_PORT = spi0;
+constexpr uint FLASH_PIN_MISO = 0;
+constexpr uint FLASH_PIN_SCK = 2;
+constexpr uint FLASH_PIN_MOSI = 3;
+constexpr uint FLASH_PIN_CS = 1;
+constexpr uint FLASH_PIN_RST = 5;
+
+// --- QSPI flash size (on-board) ---
+constexpr uint32_t QSPI_FLASH_SIZE = 2 * 1024 * 1024;  // 2MB (W25Q16JV)
+
+// --- NeoPixel ---
+constexpr uint PIN_NEOPIXEL = 4;
+
+// --- I2C (sensors) --- (J8 pins 3/4)
+inline auto SENSOR_I2C_PORT = i2c1;
+constexpr uint PIN_I2C_SDA = J8::PIN_3;  // GPIO 26
+constexpr uint PIN_I2C_SCL = J8::PIN_4;  // GPIO 27
+
+// --- Analog/digital inputs ---
+constexpr uint PIN_A0 = J8::PIN_3;  // GPIO 26
+constexpr uint PIN_A1 = J8::PIN_4;  // GPIO 27
+
+// --- PMU UART (UART1 on GPIO8/9) ---
+inline auto PMU_UART_PORT = uart1;
+constexpr uint PMU_UART_TX_PIN = 8;
+constexpr uint PMU_UART_RX_PIN = 9;
+
+// --- Default stdio UART (UART0 on J6 header — no conflict with PMU on UART1) ---
+constexpr int DEFAULT_UART = 0;
+constexpr int DEFAULT_UART_TX_PIN = J6::PIN_10;  // GPIO 28 (UART0 TX)
+constexpr int DEFAULT_UART_RX_PIN = J6::PIN_9;   // GPIO 29 (UART0 RX)
+
+// --- API UART (hub ↔ Raspberry Pi / CM5) — UART0 on J6 (stdio is on USB CDC) ---
+inline auto API_UART_PORT = uart0;
+constexpr uint API_UART_TX_PIN = J6::PIN_10;  // GPIO 28
+constexpr uint API_UART_RX_PIN = J6::PIN_9;   // GPIO 29
+
+// --- Valve / Motor pins (4 valves, J7 header) ---
+constexpr uint8_t NUM_VALVES = 4;
+constexpr uint8_t PIN_MOTOR_HI_1 = J7::PIN_10;  // GPIO 36
+constexpr uint8_t PIN_MOTOR_HI_2 = J7::PIN_8;   // GPIO 38
+constexpr uint8_t PIN_MOTOR_LO_1 = J7::PIN_6;   // GPIO 40
+constexpr uint8_t PIN_MOTOR_LO_2 = J7::PIN_4;   // GPIO 42
+constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
+    J7::PIN_9,  // VALVE_1 = GPIO 37
+    J7::PIN_7,  // VALVE_2 = GPIO 39
+    J7::PIN_3,  // VALVE_3 = GPIO 43
+    J7::PIN_5,  // VALVE_4 = GPIO 41
+};
+
+// --- Curtain motor pins (greenhouse variant, J7 header) ---
+constexpr uint8_t PIN_CURTAIN_OPEN = J7::PIN_6;   // GPIO 40
+constexpr uint8_t PIN_CURTAIN_CLOSE = J7::PIN_8;  // GPIO 38
+
+}  // namespace Board

--- a/src/modes/hub_mode.cpp
+++ b/src/modes/hub_mode.cpp
@@ -70,8 +70,8 @@ void HubMode::onStart()
     logger.info("- Managing node registrations");
     logger.info("- Routing node-to-node messages");
     logger.info("- Blue LED indicates hub status");
-    logger.info("- API UART on pins %d/%d @ %d baud", Board::API_UART_TX_PIN, Board::API_UART_RX_PIN,
-                API_UART_BAUD);
+    logger.info("- API UART on pins %d/%d @ %d baud", Board::API_UART_TX_PIN,
+                Board::API_UART_RX_PIN, API_UART_BAUD);
 
     // Initialize serial input buffer
     serial_input_pos_ = 0;

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -22,7 +22,9 @@ constexpr uint32_t HEARTBEAT_INTERVAL_MS = 60000;  // 60 seconds
 #include "../board/board_pins.h"
 
 // Board version identifier stored in persisted state
-#ifdef BOARD_V4
+#if defined(BOARD_V5)
+constexpr uint8_t IRRIGATION_BOARD_VERSION = 5;
+#elif defined(BOARD_V4)
 constexpr uint8_t IRRIGATION_BOARD_VERSION = 4;
 #else
 constexpr uint8_t IRRIGATION_BOARD_VERSION = 3;

--- a/src/modes/sensor_mode.cpp
+++ b/src/modes/sensor_mode.cpp
@@ -8,7 +8,7 @@
 #include "hardware/i2c.h"
 #include "hardware/watchdog.h"
 
-#ifdef BOARD_V4
+#if defined(BOARD_V4) || defined(BOARD_V5)
 #include "../board/board_pins.h"
 #endif
 
@@ -44,9 +44,9 @@ void SensorMode::onStart()
     logger.debug("LED: orange=init, yellow=sync, green=ok, orange=degraded, red=error");
 
     // Initialize external flash for sensor data storage
-#ifdef BOARD_V4
-    ExternalFlashPins v4_flash_pins = {.cs = Board::FLASH_PIN_CS, .reset = Board::FLASH_PIN_RST};
-    external_flash_ = std::make_unique<ExternalFlash>(Board::FLASH_SPI_PORT, v4_flash_pins);
+#if defined(BOARD_V4) || defined(BOARD_V5)
+    ExternalFlashPins flash_pins = {.cs = Board::FLASH_PIN_CS, .reset = Board::FLASH_PIN_RST};
+    external_flash_ = std::make_unique<ExternalFlash>(Board::FLASH_SPI_PORT, flash_pins);
 #else
     external_flash_ = std::make_unique<ExternalFlash>();
 #endif

--- a/src/util/sensor_pmu_manager.h
+++ b/src/util/sensor_pmu_manager.h
@@ -44,7 +44,9 @@ constexpr uint8_t STATE_VERSION = 4;
 constexpr uint8_t CYCLE_FAILURE_THRESHOLD = 3;
 
 // Board version identifier stored in persisted state
-#ifdef BOARD_V4
+#if defined(BOARD_V5)
+constexpr uint8_t PERSISTED_BOARD_VERSION = 5;
+#elif defined(BOARD_V4)
 constexpr uint8_t PERSISTED_BOARD_VERSION = 4;
 #else
 constexpr uint8_t PERSISTED_BOARD_VERSION = 3;


### PR DESCRIPTION
## Summary
v5 respins v4's PCB to fix the wiring defects we've been working around:
- LoRa MOSI/SCK no longer swapped → hardware SPI1 works directly (no bit-bang)
- SX1262 DIO1 / BUSY routed natively (no bodge wires)
- PMU UART RX on GPIO9 functional (no bodge to GPIO21)

Same RP2350B, same flash, same connector layout — software-visible diff is which SPI driver gets used for LoRa and a new \`BOARD_V5\` compile flag.

## Changes
- New SDK board header \`boards/bramble_v5.h\` (referenced via \`PICO_BOARD=bramble_v5\`)
- New pin map \`src/board/bramble_v5_pins.h\` (valves/motors on J7, sensors on I2C J8 pins 3/4, PMU UART1 on GPIO 8/9)
- \`src/board/board_pins.h\` dispatches to v5 when \`BOARD_V5\` is defined
- \`CMakeLists.txt\` accepts \`BOARD_VERSION=V5\` with a \`_v5\` executable suffix
- \`main.cpp\` uses hardware \`SPIDevice\` (not \`BitBangSPIDevice\`) for v5 LoRa
- \`src/modes/sensor_mode.cpp\` widens \`BOARD_V4\` guards to \`V4 || V5\` for external-flash init
- \`src/util/sensor_pmu_manager.h\` + \`src/modes/irrigation_mode.cpp\`: \`PERSISTED_BOARD_VERSION = 5\` / \`IRRIGATION_BOARD_VERSION = 5\` so the PMU state blob carries the right hardware-rev tag (state is rejected if board version doesn't match)

## Test plan
- [ ] \`/bramble-build SENSOR -DBOARD_VERSION=V5\` produces \`bramble_sensor_v5_sx1262.elf\` cleanly
- [ ] \`/bramble-build IRRIGATION -DBOARD_VERSION=V5\` ditto
- [ ] Flash to a v5 board, confirm LoRa works (hub registration succeeds)
- [ ] Confirm v4 build still works (regression check on the widened guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)