### PR TITLE
chore: commit project tooling, plans, docs, v4 bringup test

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,67 @@
+# Smart Commit - Atomic Commit Analyzer
+
+Analyze the current git changes and propose a set of atomic commits using conventional commit style.
+
+## Instructions
+
+1. **Gather all changes** by running these commands:
+   - `git status` - see all modified, staged, and untracked files
+   - `git diff` - see unstaged changes
+   - `git diff --cached` - see staged changes
+   - `git diff HEAD` - see all changes (staged + unstaged) combined
+
+2. **Analyze the changes** and group them into logical atomic units. Consider:
+   - Files that change together for a single purpose
+   - Separation of concerns (don't mix features with refactors)
+   - Test files should typically go with their implementation
+   - Config changes may be separate or bundled depending on context
+
+3. **Propose atomic commits** using conventional commit format:
+   ```
+   <type>(<scope>): <description>
+
+   [optional body]
+   ```
+
+   **Types:**
+   - `feat` - new feature
+   - `fix` - bug fix
+   - `docs` - documentation only
+   - `style` - formatting, no code change
+   - `refactor` - code change that neither fixes nor adds
+   - `test` - adding or updating tests
+   - `chore` - build, config, tooling changes
+   - `perf` - performance improvement
+
+   **Scope** (optional): component or area affected (e.g., `api`, `auth`, `storage`)
+
+4. **Output format** - Present the proposed commits as:
+
+   ```
+   ## Proposed Commits (in order)
+
+   ### Commit 1: <type>(<scope>): <message>
+   **Files:**
+   - path/to/file1.py
+   - path/to/file2.py
+
+   **Rationale:** Why these changes belong together
+
+   ---
+
+   ### Commit 2: ...
+   ```
+
+5. **After presenting**, ask the user if they want to:
+   - Proceed with creating these commits (you'll stage and commit each group)
+   - Modify the grouping
+   - See more details about specific changes
+
+## Important Rules
+
+- Keep commits atomic: each should be a single logical change
+- Each commit should leave the codebase in a working state if possible
+- Don't mix unrelated changes even if they're in the same file
+- Prefer more smaller commits over fewer large ones
+- Use imperative mood in commit messages ("add" not "added")
+- Keep the first line under 72 characters

--- a/.claude/commands/sort-tmux-panes.md
+++ b/.claude/commands/sort-tmux-panes.md
@@ -1,0 +1,51 @@
+# Sort Tmux Windows
+
+Reorganize tmux windows by category for a cleaner workspace.
+
+## Instructions
+
+1. **List all windows** to see current state:
+   ```bash
+   tmux list-windows -F '#{window_index}: #{window_id} - #{pane_current_command} (#{pane_title})'
+   ```
+
+2. **Categorize windows** into groups (in order of priority):
+   - **Claude**: Windows running claude code (command contains version like `2.1.x`)
+   - **SSH**: Windows with ssh sessions
+   - **Git**: Windows running git commands
+   - **Shell**: Windows running zsh, bash, or similar shells
+   - **Other**: Everything else (node, vim, etc.)
+
+3. **Reorder windows** using this approach:
+   - Move all windows to temporary high positions (100+) first to avoid index conflicts
+   - Then move them back to positions 1, 2, 3... in the desired category order
+
+   ```bash
+   # Example: Move window @0 to temp position, then back to final position
+   tmux move-window -s @{window_id} -t {temp_position}
+   tmux move-window -s {temp_position} -t {final_position}
+   ```
+
+4. **Verify the result**:
+   ```bash
+   tmux list-windows -F '#{window_index}: #{pane_current_command} (#{pane_title})'
+   ```
+
+## Example Output
+
+After sorting, windows should be ordered like:
+```
+1: claude (Project A)
+2: claude (Project B)
+3: ssh (server1)
+4: ssh (server2)
+5: git (repo)
+6: zsh (local)
+7: node (dev server)
+```
+
+## Notes
+
+- Window IDs (@0, @1, etc.) are stable across moves; use them for reliable targeting
+- The current window will remain selected after reordering
+- If a category has no windows, skip it and continue with the next

--- a/.claude/skills/bramble-flash/skill.md
+++ b/.claude/skills/bramble-flash/skill.md
@@ -1,0 +1,51 @@
+---
+name: bramble-flash
+description: Flash RP2040 firmware using OpenOCD and CMSIS-DAP debug probe.
+---
+
+# Bramble Flash
+
+Flash bramble firmware to the connected RP2040 device using OpenOCD.
+
+## Arguments
+
+- `$ARGUMENTS` - Hardware variant: SENSOR, IRRIGATION, CONTROLLER, HUB, or GENERIC (default: SENSOR)
+
+## Instructions
+
+1. **Parse the variant argument**
+   - If `$ARGUMENTS` is provided and matches a valid variant (SENSOR, IRRIGATION, CONTROLLER, HUB, GENERIC), use it
+   - Otherwise default to SENSOR
+   - The ELF file will be `build/bramble_<variant>.elf` (lowercase)
+
+2. **Verify the ELF file exists**
+   Check that `build/bramble_<variant>.elf` exists. If not, tell the user to run `/bramble-build <VARIANT>` first.
+
+3. **Flash the firmware**
+   Use OpenOCD to flash via CMSIS-DAP:
+   ```bash
+   ~/.pico-sdk/openocd/0.12.0+dev/openocd \
+     -s ~/.pico-sdk/openocd/0.12.0+dev/scripts \
+     -f interface/cmsis-dap.cfg \
+     -f target/rp2040.cfg \
+     -c "adapter speed 5000" \
+     -c "program build/bramble_<variant>.elf verify reset exit" 2>&1
+   ```
+
+4. **Report results**
+   - On success: Report that firmware was flashed and verified successfully
+   - On failure: Report the OpenOCD error output
+
+## Error Handling
+
+- If ELF file missing: Tell user to build first with `/bramble-build <VARIANT>`
+- If "no device found": Debug probe is not connected or not recognized
+- Other errors: Report the OpenOCD error output
+
+## Example Usage
+
+```
+/bramble-flash           # Flash SENSOR variant
+/bramble-flash SENSOR    # Flash SENSOR variant
+/bramble-flash IRRIGATION # Flash IRRIGATION variant
+```

--- a/.claude/skills/bramble-hub-logs/skill.md
+++ b/.claude/skills/bramble-hub-logs/skill.md
@@ -1,0 +1,98 @@
+---
+name: bramble-hub-logs
+description: Fetch Docker logs from the bramble hub via SSH and search for patterns.
+---
+
+# Bramble Hub Logs
+
+Fetch logs from Docker containers running on the bramble hub (Raspberry Pi) via SSH, optionally filtering by a pattern.
+
+## Arguments
+
+`$ARGUMENTS` - Pattern to search for, plus optional flags
+- `<pattern>` - Text or regex pattern to search for in the logs (required)
+- `--container <name>` - Docker container name (default: search all containers)
+- `--lines <N>` - Number of log lines to fetch (default: 200)
+- `--since <duration>` - Only show logs since duration (e.g., `1h`, `30m`, `2h`) (default: 1h)
+
+## Instructions
+
+### 1. Parse Arguments
+
+Extract from `$ARGUMENTS`:
+- **pattern**: The search pattern (first positional argument, required)
+- **container**: From `--container` flag, or empty for all containers
+- **lines**: From `--lines` flag, default 200
+- **since**: From `--since` flag, default "1h"
+
+If no pattern is provided, ask the user what they want to search for.
+
+### 2. SSH Connection Details
+
+```
+Host: bramble-hub.local
+SSH Key: ~/.ssh/bramble_hub
+User: root (required for Docker access)
+```
+
+### 3. Fetch Logs
+
+If a specific container is given:
+```bash
+ssh -i ~/.ssh/bramble_hub -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new root@bramble-hub.local \
+  "docker logs --tail <lines> --since <since> <container> 2>&1" 2>&1
+```
+
+If no container specified, first list running containers, then fetch logs from all:
+```bash
+# List containers
+ssh -i ~/.ssh/bramble_hub -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new root@bramble-hub.local \
+  "docker ps --format '{{.Names}}'" 2>&1
+
+# Then for each container, fetch logs
+ssh -i ~/.ssh/bramble_hub -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new root@bramble-hub.local \
+  "docker logs --tail <lines> --since <since> <container_name> 2>&1" 2>&1
+```
+
+### 4. Filter by Pattern
+
+After fetching logs, use Grep or manual filtering to find lines matching the pattern. Include 2 lines of context before and after each match for readability.
+
+### 5. Present Results
+
+Report:
+- Which container(s) were searched
+- Number of matching lines found
+- The matching lines with context, grouped by container
+- A brief summary of what the matches suggest
+
+If no matches found, report that and suggest:
+- Trying a broader pattern
+- Increasing `--since` duration
+- Checking a different container
+
+### 6. Analyze Matches
+
+After showing the matches, provide a brief analysis:
+- Are there error patterns?
+- Is there a trend (increasing frequency, etc.)?
+- Any actionable recommendations?
+
+## Example Usage
+
+```
+/bramble-hub-logs LIST_NODES                     # Search for LIST_NODES in all containers, last 1h
+/bramble-hub-logs timeout --since 2h             # Search for "timeout" in last 2 hours
+/bramble-hub-logs "error" --container bramble-api # Search specific container
+/bramble-hub-logs SENSOR_DATA --lines 500        # Get more lines
+```
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| SSH connection refused | Check that the Pi is online and SSH is running |
+| Permission denied | Verify SSH key at ~/.ssh/bramble_hub exists and has correct permissions |
+| Host not found | Check that bramble-hub.local is resolvable (mDNS) or use IP address |
+| No containers running | Report that Docker has no running containers |
+| Docker not found | Report that Docker is not installed or not in PATH |

--- a/.claude/skills/bramble-logs/skill.md
+++ b/.claude/skills/bramble-logs/skill.md
@@ -1,0 +1,151 @@
+---
+name: bramble-logs
+description: Analyze bramble node logs to identify errors, track communication, and summarize node health.
+---
+
+# Bramble Log Analyzer
+
+Analyze logs from bramble nodes (sensor, irrigation, hub) to diagnose issues and monitor system health. Optimized for pasting serial monitor output.
+
+## Arguments
+
+`$ARGUMENTS` - Optional: file path and/or filter flags
+- `<filepath>` - Path to log file (if omitted, prompt user to paste logs)
+- `--module <name>` - Filter by module (SENSOR, IRRIG, HubMode, PMU, etc.)
+- `--level <ERR|WARN|INFO|DBG>` - Minimum log level to show
+- `--node <0xXXXX>` - Filter by node address
+- `--errors` - Show only errors and warnings
+- `--detailed` - Show full detailed analysis
+
+## Instructions
+
+### 1. Obtain Log Content
+
+If a file path is provided in `$ARGUMENTS`:
+- Use the Read tool to read the file contents
+- If file not found, report error and stop
+
+If no file path provided:
+- Ask the user: "Please paste your bramble log output. You can paste multiple lines - just let me know when you're done."
+- Wait for the user to provide logs before proceeding with analysis
+
+### 2. Parse Log Format
+
+Bramble firmware logs follow this format:
+```
+[YYYY-MM-DD HH:MM:SS] PREFIX [MODULE]: message
+[+<milliseconds>ms] PREFIX [MODULE]: message
+```
+
+**Prefixes** (severity high to low): `ERR`, `WARN`, `INFO`, `DBG`
+
+**Common Modules**:
+- `SENSOR` - Sensor mode operations
+- `IRRIG` - Irrigation mode operations
+- `HubMode` - Hub mode operations
+- `PMU`, `PMU_RX`, `PMU_REL` - Power management
+- `AddressManager` - LoRa address management
+- `HubRouter` - Hub routing operations
+- `ReliableMessenger` - Reliable message delivery
+- `CHT832X` - Temperature/humidity sensor
+- `ValveCtrl` - Valve controller
+- `LORA`, `NETWORK` - LoRa communication
+
+Also parse Hub UART output patterns:
+```
+SENSOR_DATA <node_addr> <device_id> TEMP|HUM <value>
+SENSOR_BATCH <node_addr> <device_id> <record_count>
+Hub stats - Routed: X, Queued: Y, Dropped: Z
+Unknown node 0xXXXX - sending reregister request
+Registered nodes: N
+```
+
+### 3. Apply Filters (if specified)
+
+If filters are in `$ARGUMENTS`:
+- `--module <name>`: Keep only entries from that module
+- `--level <level>`: Keep entries at or above level (ERR > WARN > INFO > DBG)
+- `--node <addr>`: Keep entries mentioning that node address
+- `--errors`: Equivalent to `--level WARN`
+
+### 4. Analyze and Report
+
+#### Always Include:
+
+**a) Overview**
+- Time range (first to last timestamp)
+- Total log lines analyzed
+- Error count, warning count
+
+**b) Errors and Warnings** (grouped by type)
+Focus on these categories:
+- **Initialization failures**: `Failed to initialize`, sensor/flash init errors
+- **Communication errors**: `Failed to send`, `timeout`, `CRC error`
+- **Protocol issues**: `Unknown node`, `Invalid`, `NULL.*payload`
+- **Power/PMU errors**: `Ready for sleep failed`, PMU communication issues
+
+**c) Communication Analysis** (primary focus)
+- Message statistics from `Hub stats - Routed: X, Queued: Y, Dropped: Z`
+- Delivery rate calculation (routed / (routed + dropped))
+- RSSI values from `RSSI=-XX dBm` patterns (signal quality)
+- Node registration status from `Registered nodes:` lines
+- Unregistered node attempts from `Unknown node 0xXXXX` patterns
+
+**d) Node Health Summary** (if multi-node data present)
+For each node detected:
+- Node address and type (if determinable)
+- Status: Active/Inactive (based on message recency)
+- Message count
+- Average RSSI (if available)
+- Error count for that node
+
+**e) Anomalies Detected**
+- Sensor out of range: temperature < -40C or > 85C, humidity < 0% or > 100%
+- Registration loops: repeated `reregister request` for same node
+- Communication gaps: long periods without messages from a node
+- Clock issues: `RTC not running`, timestamp discontinuities
+
+#### If `--detailed` flag:
+Additionally include:
+- Full chronological list of errors/warnings
+- All matching log entries
+- Per-module breakdown of activity
+- Sensor data statistics (min/max/avg readings if present)
+
+### 5. Provide Recommendations
+
+Based on findings, suggest specific actions:
+
+| Issue | Recommendation |
+|-------|----------------|
+| Initialization errors | Check wiring, verify hardware connections |
+| Communication timeouts | Check antenna connection, node positioning, reduce distance |
+| Low RSSI (< -100 dBm) | Move nodes closer, check for interference, verify antenna |
+| Unknown node errors | Node lost persisted address - may need re-registration |
+| PMU errors | Check UART connection between RP2040 and PMU |
+| CRC errors | Check for RF interference, verify LoRa settings match |
+| Sensor out of range | Check sensor placement, verify calibration |
+| High drop rate | Network congestion - consider staggering transmissions |
+
+## Example Usage
+
+```
+/bramble-logs                              # Prompt for pasted logs, show summary
+/bramble-logs ~/logs/hub.log               # Analyze file
+/bramble-logs --errors                     # Show only errors/warnings from pasted logs
+/bramble-logs --module HubMode --detailed  # Detailed hub analysis
+/bramble-logs --node 0x0004                # Filter to specific node
+```
+
+## Error Patterns Quick Reference
+
+| Pattern | Meaning |
+|---------|---------|
+| `Failed to initialize external flash` | SPI flash chip not responding |
+| `Failed to initialize CHT832X sensor` | I2C temp/humidity sensor not found |
+| `Unknown node 0xXXXX` | Message from unregistered node address |
+| `Hub sync timeout` | Hub didn't respond to node heartbeat |
+| `Ready for sleep failed` | PMU sleep command failed |
+| `Failed to send` | LoRa radio transmission error |
+| `CRC error` | Message corruption detected |
+| `reregister request` | Hub asking unknown node to re-register |

--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: git
+description: Unified git operations via sub-agent. Keeps verbose output out of main context.
+---
+
+# Unified Git Skill
+
+Route all git operations through a sub-agent to keep verbose output (diffs, logs, status) out of the main conversation. Only a concise summary flows back.
+
+## Arguments
+
+`$ARGUMENTS` — The git operation and any extra arguments. Format: `<operation> [args...]`
+
+## Supported Operations
+
+| Operation | Usage | Description |
+|-----------|-------|-------------|
+| `status` | `/git status` | Summarize working tree state |
+| `commit` | `/git commit` or `/git commit "message"` | Analyze changes, create atomic commits |
+| `branch` | `/git branch feature/foo` | Create and switch to a new branch |
+| `checkout` | `/git checkout main` | Switch branches |
+| `pr` | `/git pr` or `/git pr "title"` | Push and create a pull request |
+| `merge` | `/git merge` or `/git merge 42` | Merge a PR after checking status |
+| `push` | `/git push` | Push current branch to remote |
+| `sync` | `/git sync` | Fetch and rebase on main |
+| `stash` | `/git stash` or `/git stash pop` | Stash or restore changes |
+| `log` | `/git log` | Show and summarize recent commits |
+| `diff` | `/git diff` or `/git diff main` | Summarize changes |
+| `address-comments` | `/git address-comments` | Fetch PR comments, fix issues, commit, push |
+| `tag` | `/git tag v1.0.0` | Create and push a tag |
+
+## Instructions
+
+### Step 1: Parse the operation
+
+Extract the operation name and remaining arguments from `$ARGUMENTS`:
+- The first word is the operation (e.g., `commit`, `pr`, `status`)
+- Everything after the first word is passed as extra args to the sub-agent
+- If `$ARGUMENTS` is empty, default to `status`
+
+### Step 2: Dispatch to sub-agent
+
+Use the **Task** tool with `subagent_type: general-purpose` to dispatch the operation. Use the appropriate prompt from the operation reference below.
+
+**Every sub-agent prompt MUST include these rules at the top:**
+
+```
+## Git Safety Rules
+- NEVER commit directly to main/master. If on main, stop and report an error.
+- NEVER force push (--force, --force-with-lease) unless the user explicitly said to.
+- NEVER use --no-verify or skip hooks.
+- NEVER amend commits unless explicitly asked.
+- NEVER run destructive commands (reset --hard, clean -f, branch -D) unless explicitly asked.
+- Use conventional commit style: <type>(<scope>): <description>
+- Keep the first line under 72 characters, use imperative mood.
+- Co-author line: Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+## Output Format
+When done, structure your FINAL response EXACTLY as:
+
+RESULT: SUCCESS | FAILED
+SUMMARY: <concise 1-3 line summary of what happened>
+DETAILS: <optional extra info like PR URLs, commit SHAs, branch names>
+```
+
+### Step 3: Return the result
+
+After the sub-agent completes, relay its structured response to the user. Do NOT echo raw git output — only the SUMMARY and DETAILS lines.
+
+---
+
+## Operation Reference
+
+Use these prompts when dispatching each operation. Replace `{args}` with the extra arguments parsed in Step 1.
+
+---
+
+### `status`
+
+```
+{git safety rules}
+
+Run `git status` and `git stash list`. Provide a concise summary:
+- Current branch
+- Ahead/behind remote
+- Number of staged, unstaged, and untracked files (with filenames if < 10)
+- Any active stashes
+
+{output format}
+```
+
+---
+
+### `commit`
+
+```
+{git safety rules}
+
+Analyze all uncommitted changes and create atomic commits.
+
+User-provided message (if any): {args}
+
+Steps:
+1. Run: git status, git diff, git diff --cached, git log --oneline -5
+2. If on main/master, STOP and report FAILED — must be on a feature branch.
+3. If no changes exist, report FAILED with "nothing to commit".
+4. Group changes into logical atomic commits. Consider:
+   - Files that change together for a single purpose
+   - Separate features from refactors from fixes
+   - Test files go with their implementation
+   - Each commit should leave the codebase in a working state
+5. For each commit group:
+   a. Stage only the relevant files: git add <file1> <file2> ...
+   b. Commit with conventional commit message using a HEREDOC:
+      git commit -m "$(cat <<'EOF'
+      <type>(<scope>): <description>
+
+      Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+      EOF
+      )"
+   c. If user provided a message, use it for the primary commit.
+6. Prefer more smaller commits over fewer large ones.
+
+{output format}
+Include commit SHAs and messages in DETAILS.
+```
+
+---
+
+### `branch`
+
+```
+{git safety rules}
+
+Create a new branch and switch to it.
+
+Branch name: {args}
+
+Steps:
+1. If no branch name provided, report FAILED — a name is required.
+2. Run: git checkout -b {args}
+3. Confirm the branch was created.
+
+{output format}
+```
+
+---
+
+### `checkout`
+
+```
+{git safety rules}
+
+Switch to the specified branch.
+
+Target: {args}
+
+Steps:
+1. If no target provided, report FAILED — a branch name is required.
+2. Check for uncommitted changes with git status. If present, warn in DETAILS but proceed.
+3. Run: git checkout {args}
+4. Confirm the switch.
+
+{output format}
+```
+
+---
+
+### `pr`
+
+```
+{git safety rules}
+
+Push the current branch and create a pull request.
+
+User-provided title (if any): {args}
+
+Steps:
+1. Run: git branch --show-current, git status, git log main..HEAD --oneline, git diff main...HEAD --stat
+2. If on main/master, STOP and report FAILED.
+3. If there are uncommitted changes, warn in DETAILS but proceed.
+4. Push the branch: git push -u origin $(git branch --show-current)
+5. Analyze the commits and diff to generate:
+   - A clear, descriptive PR title (under 70 chars). Use user title if provided.
+   - A summary body with bullet points of what changed
+   - A test plan section
+6. Create the PR using a HEREDOC for the body:
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullet points>
+
+   ## Test plan
+   <checklist>
+
+   Generated with Claude Code
+   EOF
+   )"
+7. Report the PR URL in DETAILS.
+
+{output format}
+```
+
+---
+
+### `merge`
+
+```
+{git safety rules}
+
+Merge a pull request.
+
+PR number or args: {args}
+
+Steps:
+1. If no PR number provided, find it: gh pr list --head $(git branch --show-current) --json number --jq '.[0].number'
+2. Check PR status: gh pr view <number> --json state,reviewDecision,statusCheckRollup
+3. If checks are failing, report in DETAILS but proceed with merge.
+4. Merge with squash: gh pr merge <number> --squash --delete-branch
+5. Switch to main and pull: git checkout main && git pull
+
+{output format}
+Include the merged PR number and title in DETAILS.
+```
+
+---
+
+### `push`
+
+```
+{git safety rules}
+
+Push the current branch to remote.
+
+Extra args: {args}
+
+Steps:
+1. Run: git branch --show-current
+2. If on main/master, STOP and report FAILED — don't push directly to main.
+3. Push: git push -u origin $(git branch --show-current) {args}
+4. Report status.
+
+{output format}
+```
+
+---
+
+### `sync`
+
+```
+{git safety rules}
+
+Sync the current branch with main.
+
+Steps:
+1. Run: git branch --show-current, git status
+2. If there are uncommitted changes, stash them first: git stash
+3. Fetch: git fetch origin
+4. If on main: git pull origin main
+5. If on a feature branch: git rebase origin/main
+6. If changes were stashed: git stash pop
+7. If rebase conflicts occur, report FAILED with conflict details.
+
+{output format}
+```
+
+---
+
+### `stash`
+
+```
+{git safety rules}
+
+Manage git stash.
+
+Sub-command: {args}
+
+Steps:
+1. If no args or args is empty: git stash push -m "stash from /git"
+2. If args is "pop": git stash pop
+3. If args is "list": git stash list
+4. If args is "drop": git stash drop
+5. If args starts with "pop", "apply", "drop", or "show" followed by a number: git stash {args}
+6. Otherwise: git stash {args}
+
+{output format}
+```
+
+---
+
+### `log`
+
+```
+{git safety rules}
+
+Show recent commit history.
+
+Extra args: {args}
+
+Steps:
+1. Run: git log --oneline --graph --decorate -20 {args}
+2. Summarize: current branch, total commits shown, key themes/patterns in recent work.
+
+{output format}
+Include the formatted log summary in DETAILS.
+```
+
+---
+
+### `diff`
+
+```
+{git safety rules}
+
+Summarize changes.
+
+Diff target: {args}
+
+Steps:
+1. If no args: run git diff and git diff --cached to show all uncommitted changes.
+2. If args provided (e.g., "main"): run git diff {args}
+3. Summarize the diff:
+   - Number of files changed
+   - For each file: brief description of what changed (added, modified, deleted, and a short summary)
+   - Total lines added/removed
+4. Do NOT output the raw diff. Summarize it.
+
+{output format}
+Include the file-by-file summary in DETAILS.
+```
+
+---
+
+### `address-comments`
+
+```
+{git safety rules}
+
+Fetch PR review comments, address open issues, commit fixes, and push.
+
+Extra args: {args}
+
+Steps:
+1. Get current branch: git branch --show-current
+2. Find PR number: gh pr list --head <branch> --json number --jq '.[0].number'
+3. If no PR found, report FAILED.
+4. Fetch review comments:
+   - gh api repos/:owner/:repo/pulls/<number>/comments --jq '.[] | {path: .path, line: .line, body: .body, id: .id}'
+   - gh pr view <number> --json reviews --jq '.reviews[] | {body: .body, state: .state}'
+5. Categorize comments as FIXED (already addressed in code) or OPEN (still needs work).
+6. For each OPEN comment:
+   a. Read the relevant file
+   b. Apply the fix
+   c. Verify the change makes sense
+7. Stage and commit fixes:
+   git add <changed files>
+   git commit -m "$(cat <<'EOF'
+   fix: address PR review comments
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+8. Push: git push
+
+{output format}
+Include count of fixed vs already-resolved comments in DETAILS.
+```
+
+---
+
+### `tag`
+
+```
+{git safety rules}
+
+Create and push a git tag.
+
+Tag specification: {args}
+
+Steps:
+1. If no args, report FAILED — a tag name is required.
+2. Create the tag: git tag {args}
+3. Push the tag: git push origin {args}
+
+{output format}
+Include the tag name and commit it points to in DETAILS.
+```
+
+---
+
+## Error Handling
+
+If `$ARGUMENTS` contains an unrecognized operation, report the error and list available operations. Do NOT dispatch a sub-agent.
+
+## Examples
+
+```
+/git status              → Dispatches status sub-agent, returns branch + file summary
+/git commit              → Analyzes changes, creates atomic commits, returns SHAs
+/git commit "fix typo"   → Creates single commit with provided message
+/git branch feature/foo  → Creates branch, returns confirmation
+/git pr                  → Pushes, creates PR, returns URL
+/git pr "Add logging"    → Pushes, creates PR with given title, returns URL
+/git merge               → Merges current branch's PR, returns confirmation
+/git merge 42            → Merges PR #42, returns confirmation
+/git sync                → Fetches and rebases on main
+/git diff main           → Summarizes diff against main
+/git address-comments    → Fetches and fixes PR review comments
+/git tag v1.0.0          → Creates and pushes tag
+```

--- a/.claude/skills/github-create-issue/SKILL.md
+++ b/.claude/skills/github-create-issue/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-create-issue
+description: Creates a GitHub issue from conversation context or user-provided description.
+---
+
+# Create GitHub Issue
+
+## Instructions
+
+1. Review the conversation context to identify:
+   - The problem or feature being discussed
+   - Any proposed solutions or requirements
+   - Relevant technical details
+
+2. If the user provided a specific description or quoted text, use that as the basis for the issue
+
+3. Create a well-structured issue with:
+   - **Title**: Clear, concise summary (imperative mood, e.g., "Add subsecond precision to timestamps")
+   - **Body** containing:
+     - `## Problem` - What's the issue or missing feature?
+     - `## Proposed Solution` - How should it be addressed?
+     - `## Benefits` (optional) - Why is this valuable?
+     - Code examples if relevant
+
+4. Create the issue using `gh issue create`:
+   ```bash
+   gh issue create --title "Title here" --body "$(cat <<'EOF'
+   ## Problem
+   ...
+
+   ## Proposed Solution
+   ...
+
+   EOF
+   )"
+   ```
+
+5. Report the issue URL to the user
+
+## Arguments
+
+- Optional: `[title]` - If provided, use this as the issue title
+- Optional: `[description]` - If provided, use this as additional context
+
+## Notes
+
+- If context is ambiguous, ask the user for clarification before creating
+- Keep titles under 70 characters
+- Use markdown formatting in the body for readability

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: orchestrate
+description: Decompose complex tasks into sub-tasks, delegate to sub-agents, track progress, and synthesize results.
+---
+
+# General-Purpose Task Orchestrator
+
+Decompose complex tasks into sub-tasks, delegate to sub-agents, track progress, and synthesize results.
+
+## Arguments
+
+- `$ARGUMENTS` — Task description (natural language or numbered list), OR one of:
+  - `--dry-run` flag after description — decompose and show plan only, do not execute
+  - `--sequential` flag after description — force one-at-a-time execution (no parallel dispatch)
+  - `continue` or `resume` — resume from existing TaskList state
+
+## Overview
+
+```
+/orchestrate "<task description>"
+    │
+    ▼
+Phase 1: PLAN — Analyze and decompose into sub-tasks
+    │
+    ▼
+Phase 2: TRACK — Create tasks with dependencies
+    │
+    ▼
+Phase 3: EXECUTE — Dispatch sub-agents, track progress
+    │
+    ▼
+Phase 4: SYNTHESIZE — Collect results and report
+```
+
+---
+
+## Phase 1: PLAN — Analyze and Decompose
+
+### If `$ARGUMENTS` is `continue` or `resume`:
+
+Skip to **Phase 3: EXECUTE (Resumption)**.
+
+### If `$ARGUMENTS` is a numbered list:
+
+Parse directly into sub-tasks. Each numbered item becomes one sub-task. Infer types and dependencies from the text.
+
+### If `$ARGUMENTS` is natural language:
+
+1. **Analyze the task** — Determine if codebase exploration is needed:
+   - If the task references specific files, modules, or code constructs: launch an **Explore sub-agent** via the Task tool (`subagent_type: Explore`) to understand the relevant code structure, patterns, and dependencies.
+   - If the task is self-contained (e.g., "run tests then commit"): skip exploration.
+
+2. **Decompose into sub-tasks** — Break the task into the smallest independently-completable units of work. For each sub-task, determine:
+
+   | Field | Description |
+   |-------|-------------|
+   | `id` | Sequential number (1, 2, 3...) |
+   | `title` | Short imperative description (e.g., "Extract color logic from NeoPixel HAL") |
+   | `type` | One of: `explore`, `implement`, `command`, `skill:<name>` |
+   | `depends_on` | List of sub-task IDs that must complete first (empty = independent) |
+   | `description` | Detailed instructions for the sub-agent, including file paths, acceptance criteria |
+   | `activeForm` | Present-continuous form (e.g., "Extracting color logic") |
+
+3. **Classify sub-task types** using this table:
+
+   | Type | When to use | Dispatched as |
+   |------|-------------|---------------|
+   | `explore` | Reading code, searching, answering questions | Task tool with `subagent_type: Explore` |
+   | `implement` | Writing/editing code, refactoring, fixing bugs | Task tool with `subagent_type: general-purpose` |
+   | `command` | Running shell commands (build, test, git) | Bash tool directly |
+   | `skill:<name>` | Invoking another skill (commit, bramble-build, etc.) | Skill tool with `skill: <name>` |
+
+4. **Build the dependency graph** — Independent tasks have no `depends_on`. Tasks that require output from earlier tasks list those IDs. Maximize parallelism: only add dependencies where the output of one task is genuinely needed as input to another.
+
+### Output of Phase 1
+
+Present the decomposition to the user as a numbered list:
+
+```
+Orchestration Plan for: "<original task>"
+
+Sub-tasks:
+  1. [explore] Analyze NeoPixel HAL structure
+  2. [implement] Extract color utility functions → new file (depends on: 1)
+  3. [implement] Update NeoPixel HAL to use extracted functions (depends on: 1, 2)
+  4. [skill:bramble-build] Build SENSOR variant (depends on: 2, 3)
+  5. [skill:commit] Commit changes (depends on: 4)
+
+Parallel groups:
+  - Group A (independent): [1]
+  - Group B (after 1): [2, 3] — run in parallel
+  - Group C (after 2,3): [4]
+  - Group D (after 4): [5]
+```
+
+**If `--dry-run` is present:** Stop here. Display the plan and exit.
+
+**Otherwise:** Ask the user for confirmation before proceeding using `AskUserQuestion`:
+- "Proceed with this plan?"
+- Options: "Yes, execute", "Modify plan", "Cancel"
+
+If the user selects "Modify plan", ask what changes they want and re-decompose.
+
+---
+
+## Phase 2: TRACK — Create and Wire Tasks
+
+After user confirmation:
+
+1. **Create tasks** — For each sub-task, call `TaskCreate` with:
+   - `subject`: The sub-task title
+   - `description`: The detailed description from Phase 1
+   - `activeForm`: The present-continuous form
+
+2. **Wire dependencies** — For each sub-task that has `depends_on`, call `TaskUpdate` with:
+   - `taskId`: The created task's ID
+   - `addBlockedBy`: Array of task IDs corresponding to the `depends_on` sub-task IDs
+
+   Map Phase 1 sub-task IDs (1, 2, 3...) to the actual TaskCreate IDs returned by the system.
+
+3. **Verify** — Call `TaskList` to confirm all tasks are created with correct dependency wiring.
+
+---
+
+## Phase 3: EXECUTE — Dispatch and Track
+
+### Normal Execution
+
+1. **Find ready tasks** — Call `TaskList`. Identify all tasks with status `pending` and empty `blockedBy` (no unresolved dependencies).
+
+2. **Dispatch ready tasks** — For each ready task, based on its type:
+
+   | Type | How to dispatch |
+   |------|----------------|
+   | `explore` | Task tool: `subagent_type: Explore`, prompt = task description |
+   | `implement` | Task tool: `subagent_type: general-purpose`, prompt = task description |
+   | `command` | Bash tool: run the command directly |
+   | `skill:<name>` | Skill tool: `skill: <name>`, `args: <from description>` |
+
+   **Parallel dispatch:** If multiple tasks are ready and `--sequential` is NOT set, dispatch them all in a **single message** with multiple tool calls. This is critical for performance.
+
+   **Sequential dispatch:** If `--sequential` is set, dispatch one task at a time.
+
+3. **Before dispatching each task**, call `TaskUpdate` to set `status: in_progress`.
+
+4. **Sub-agent prompt template** — When dispatching `explore` or `implement` tasks via the Task tool, use this prompt structure:
+
+   ```
+   ## Task: <title>
+
+   <description from Phase 1>
+
+   ## Output Format
+
+   When you are done, structure your final response as follows:
+
+   RESULT: SUCCESS | PARTIAL | FAILED
+   FILES_MODIFIED: <comma-separated list of files changed, or "none">
+   SUMMARY: <1-3 sentence summary of what was done>
+   ISSUES: <any problems encountered, or "none">
+   ```
+
+5. **Process results** — When a dispatched task completes:
+   - Parse the result from the sub-agent output
+   - Call `TaskUpdate` with `status: completed` on success
+   - If the result is FAILED or PARTIAL:
+     - **First failure:** Retry once with additional context from the error
+     - **Second failure:** Mark the task as completed (to unblock dependents) and record the failure. Ask the user how to proceed using `AskUserQuestion`:
+       - "Task '<title>' failed after retry. How to proceed?"
+       - Options: "Skip and continue", "Retry with different approach", "Abort orchestration"
+   - **Pass context forward:** If a completed task's output is needed by dependent tasks (e.g., file paths discovered, decisions made), include that context in the dependent task's prompt when dispatching it.
+
+6. **Iterate** — After processing results, go back to step 1. Continue until all tasks are completed or the user aborts.
+
+### Resumption (continue/resume)
+
+1. Call `TaskList` to get current state.
+2. If there are no tasks, inform the user: "No orchestration in progress. Start one with `/orchestrate <task>`."
+3. If there are tasks, display the current state:
+   - Completed tasks (with summaries if available)
+   - In-progress tasks
+   - Pending tasks (blocked and unblocked)
+4. Resume from step 1 of Normal Execution (find ready tasks and dispatch).
+
+---
+
+## Phase 4: SYNTHESIZE — Report Results
+
+After all tasks are completed (or aborted):
+
+1. **Collect results** — Call `TaskList` to get final state of all tasks.
+
+2. **Generate summary report:**
+
+   ```
+   ## Orchestration Complete
+
+   **Task:** <original task description>
+
+   ### Results
+   - Completed: X/Y tasks
+   - Failed: Z tasks (if any)
+
+   ### What was done
+   <Bullet list summarizing each completed task's outcome>
+
+   ### Files modified
+   <Deduplicated list of all files modified across sub-tasks>
+
+   ### Issues encountered
+   <Any problems or warnings from sub-tasks, or "None">
+
+   ### Suggested next steps
+   <Based on the task context, suggest logical follow-ups>
+   ```
+
+3. **Suggest skill chaining** — If appropriate, offer to run follow-up skills:
+   - After code changes: "Run `/bramble-build` to verify the build?"
+   - After successful build: "Run `/commit` to commit changes?"
+   - After commit: "Run `/github-create-pr` to open a PR?"
+
+   Use `AskUserQuestion` to offer these as options.
+
+---
+
+## Constraints
+
+- **One level deep only** — Sub-agents dispatched via the Task tool cannot spawn their own sub-agents. All decomposition happens here in the orchestrator.
+- **No shared state** — Sub-agents don't see each other's output. If task B depends on task A's output, you must include A's results in B's prompt when dispatching B.
+- **Session-scoped** — TaskCreate/TaskList state does not persist across sessions. Resumption only works within the same session.
+- **Skills from orchestrator only** — Sub-agents cannot invoke skills. If a sub-task requires a skill, type it as `skill:<name>` and the orchestrator calls the Skill tool directly.
+- **Context budget** — Keep sub-agent prompts focused and concise. Include only the information the sub-agent needs, not the entire orchestration context.
+
+## Example Invocations
+
+```
+/orchestrate Refactor the NeoPixel HAL to separate hardware access from color logic
+/orchestrate --dry-run Add input validation to the LoRa message handler
+/orchestrate --sequential 1. Read src/lora/sx1276.cpp 2. Summarize its structure 3. Add error logging
+/orchestrate continue
+```

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dashboard/dist/
 
 # Claude Code workspace files
 .claude/worktrees/
+.claude/settings.local.json
 
 # CMake files
 CMakeCache.txt

--- a/docs/battery-life-analysis.md
+++ b/docs/battery-life-analysis.md
@@ -1,0 +1,64 @@
+# Battery Life Analysis - Bramble Sensor Node
+
+**Date:** 2026-01-30
+**Firmware:** v0.2.16
+**Hardware:** SENSOR variant
+
+## Measured Values
+
+| Parameter | Value | Method |
+|-----------|-------|--------|
+| Wake current | 60mA | 6mV over 0.1Ω shunt |
+| Sleep current | ~µA | Not measurable on regular multimeter |
+
+## Wake Cycle Timing
+
+### Quiet Wake (no transmission) - ~1.5 seconds
+
+| Phase | Duration |
+|-------|----------|
+| Boot → Sensor SM ready | 937ms |
+| Sensor read + check backlog | ~500ms |
+| **Total** | **~1.5s** |
+
+### Transmit Wake (with radio) - ~5 seconds
+
+| Phase | Duration | Notes |
+|-------|----------|-------|
+| Boot → Sensor SM ready | 937ms | PMU state restore takes 580ms |
+| Sensor read + batch transmit | ~1s | |
+| Waiting for heartbeat response | ~2s | Radio latency |
+| Batch ACK + receive window | ~1s | 500ms window + processing |
+| **Total** | **~5s** | |
+
+## Duty Cycle
+
+- Wake interval: 60 seconds
+- Transmit interval: 300 seconds (5 minutes)
+- Quiet wakes per cycle: 5
+- Transmit wakes per cycle: 1
+
+## Battery Life Calculation
+
+**Battery:** 2 packs of 3×AAA in series
+**Capacity:** ~1000mAh
+
+### Per 5-minute cycle
+
+| Activity | Time | Current | Energy |
+|----------|------|---------|--------|
+| 5 quiet wakes | 7.5s | 60mA | 0.125 mAh |
+| 1 transmit wake | 5s | 60mA | 0.083 mAh |
+| Sleep | 287s | ~0.01mA | 0.048 mAh |
+| **Total** | 300s | | **~0.26 mAh** |
+
+**Average current:** 3.1 mAh/hour
+
+### Estimated Battery Life: ~13 days
+
+## Optimization Opportunities
+
+1. **Increase wake interval** - 60s → 120s or 300s could nearly double or 5x life
+2. **Reduce transmit frequency** - batch less often than every 300s
+3. **Shorten PMU state restore** - 580ms of 937ms init is waiting for state
+4. **Add parallel battery pack** - doubles capacity to ~26 days

--- a/plans/cm5_bringup.md
+++ b/plans/cm5_bringup.md
@@ -1,0 +1,104 @@
+# CM5 Carrier Board Bringup
+
+## Context
+
+Custom CM5 carrier board is not booting cleanly on first attempts. Debug UART at TP35/TP36 (DEBUG_UART_TX/RX) + TP46 (GND), 115200 baud, has proven the module executes and reaches the kernel handoff via BL31, but kernel output is silent because the default `serial0` alias does not map to the Pi 5/CM5 dedicated debug UART (UART10 / `ttyAMA10`).
+
+The "known good" NVMe (cloned from SD on the original Pi 5 hub) boots on both the Pi 5 and is presumed to boot on the CM5. A fresh Pi OS image flashed directly to NVMe did **not** boot on the Pi 5 (reasons unclear — possibly first-boot state / NVMe detection timing). So we will clone SD → NVMe instead of flashing a fresh image, matching the known-working recipe.
+
+## Goal
+
+1. Boot the CM5 carrier reliably from NVMe.
+2. Get kernel UART output on TP35/TP36 so we can diagnose any remaining issues.
+3. Make it easy to swap drives between Pi 5 and CM5 without bricking the hub.
+
+## Steps
+
+### 1. Change boot order on the Pi 5 hub (SD preferred)
+
+Run on the hub:
+```bash
+sudo rpi-eeprom-config --edit
+```
+Change `BOOT_ORDER=0xf146` → `BOOT_ORDER=0xf641`.
+Reads right-to-left: `1`=SD first, `4`=USB, `6`=NVMe, `f`=restart.
+Save and reboot.
+
+**Rationale**: with SD first, swapping NVMes in/out won't brick the hub — it always falls back to SD.
+
+### 2. Clone SD → NVMe on the Pi 5
+
+With the target NVMe plugged in (the one we want to use in the CM5):
+```bash
+sudo apt install -y rpi-clone
+sudo rpi-clone nvme0n1
+```
+
+`rpi-clone` handles partition sizing, filesystem resize, and regenerates partition UUIDs so the clone boots cleanly.
+
+Fallback (manual):
+```bash
+sudo dd if=/dev/mmcblk0 of=/dev/nvme0n1 bs=4M status=progress conv=fsync
+sudo parted /dev/nvme0n1 resizepart 2 100%
+sudo resize2fs /dev/nvme0n1p2
+```
+
+### 3. Apply debug-UART kernel config to the cloned NVMe
+
+While still on the Pi 5 (NVMe plugged in, hub booted from SD):
+```bash
+sudo mkdir -p /mnt/boot
+sudo mount /dev/nvme0n1p1 /mnt/boot
+
+# Enable kernel UART console on CM5 dedicated debug UART
+sudo sed -i 's|console=serial0,115200|earlycon console=ttyAMA10,115200|' /mnt/boot/cmdline.txt
+
+# If the cloned cmdline doesn't have console=serial0, append the console args instead:
+# sudo sed -i 's|$| earlycon console=ttyAMA10,115200|' /mnt/boot/cmdline.txt
+
+# Ensure enable_uart=1 is present
+grep -q "^enable_uart=1" /mnt/boot/config.txt || echo "enable_uart=1" | sudo tee -a /mnt/boot/config.txt
+
+cat /mnt/boot/cmdline.txt
+sudo umount /mnt/boot
+```
+
+**Why**: Bootloader UART works via fixed debug UART routing, but the kernel's `console=serial0` alias maps to UART0/GPIO14-15, not the debug UART at TP35/TP36. Using `ttyAMA10` targets UART10 directly. `earlycon` gets output from the very first kernel instruction, before the full serial driver loads.
+
+### 4. Move NVMe to CM5 and capture UART
+
+1. Safely shut down the hub, remove NVMe.
+2. Install NVMe in the CM5 carrier's M.2 slot.
+3. Connect debug probe at 115200 8N1:
+   - Probe RX ← TP35 (CM5 TX)
+   - Probe TX → TP36 (CM5 RX, optional)
+   - Probe GND ↔ TP46
+4. Power on. Expect to see:
+   - Bootloader banner (`BOOTSYS release ...`)
+   - PCIe scan + NVMe enumeration
+   - Kernel loaded, BL31 banner
+   - **Kernel boot messages** (new — this is what we're solving for)
+   - Systemd startup
+   - Login prompt
+
+### 5. If kernel still silent after BL31
+
+Fallbacks to try, in order:
+1. Try `console=ttyS0,115200` instead of `ttyAMA10` (8250 driver).
+2. Add `loglevel=8 debug ignore_loglevel` to cmdline.
+3. Add `uart_2ndstage=1` to config.txt for more bootloader verbosity.
+4. Plan to bodge USB slave + nRPIBOOT to enable `rpiboot` — allows editing EEPROM (`UART_CONSOLE=1` for guaranteed bootloader UART on all boot stages) and flashing eMMC directly.
+
+## Done criteria
+
+- Hub boots reliably from SD regardless of which NVMe is inserted.
+- CM5 carrier boots the cloned NVMe.
+- Kernel boot messages visible on TP35 at 115200 baud.
+- Login prompt appears on UART (no network available on this carrier — no wifi, no Ethernet).
+
+## Known gotchas
+
+- CM5 module has **no wifi** on this SKU — UART is the only diagnostic channel.
+- `POWER_OFF_ON_HALT=1` in EEPROM: if the OS requests shutdown, the module powers off and the next boot may land in `partition 63` (halt state) until power is cycled. This is normal.
+- `serial0` ≠ debug UART on Pi 5/CM5. Always use `ttyAMA10` for kernel console on TP35/36.
+- Pre-existing working NVMe uses SD-derived install — do not wipe it until the cloned one is proven.

--- a/plans/factory_reset.md
+++ b/plans/factory_reset.md
@@ -1,0 +1,24 @@
+# Factory Reset Implementation
+
+## Context
+The PMU (STM32L010) has FRAM persistent storage (FM24CL16B, 2KB) storing wake interval, schedules, node state blob, and a validity flag. `SystemReset` (command 0x1A) resets the MCU but preserves FRAM. There is no way to clear persisted state — this is needed to fix issues like stale LoRa addresses.
+
+## What exists
+- `PersistentStorage::formatStorage()` — private method that zeros FRAM and writes fresh magic/version. Called automatically on first boot.
+- `invalidateNodeState()` — clears the valid flag but not the state blob
+- `WateringSchedule::clear()` — sets schedule count to 0
+- FRAM driver, I2C1, and PersistentStorage are fully wired up in main.cpp
+
+## What's needed
+1. ~~**New PMU protocol command** `FactoryReset` (e.g., 0x1B) in `pmu_protocol.h`~~ ✅
+2. ~~**Handler** in `pmu_protocol.cpp` that calls `formatStorage()` (make it public or add a `factoryReset()` method on PersistentStorage)~~ ✅
+3. ~~**ACK, then reset** — send ACK before formatting, then `NVIC_SystemReset()` after~~ ✅
+4. ~~**RP2040 side** — add `factoryReset()` to `ReliablePmuClient` and expose in `SensorPmuManager`~~ ✅
+5. **Trigger mechanism** — e.g., hub command via LoRa, or detect a GPIO button hold at boot (TODO)
+
+## Key files
+- `pmu-stm32/Core/Inc/pmu_protocol.h` — command enum
+- `pmu-stm32/Core/Src/pmu_protocol.cpp` — handler
+- `pmu-stm32/Core/Inc/persistent_storage.h` — make formatStorage public
+- `src/hal/pmu_protocol.h` — RP2040 command enum
+- `src/hal/pmu_reliability.h/.cpp` — reliable client method

--- a/plans/issue72_subsecond_timestamps.md
+++ b/plans/issue72_subsecond_timestamps.md
@@ -1,0 +1,116 @@
+# Issue #72: Add Subsecond Precision to RTC-Synced Log Timestamps
+
+## Problem Summary
+
+Currently, log timestamps lose millisecond precision after RTC sync:
+- **Before RTC sync**: `[+Xms]` - relative time with millisecond precision
+- **After RTC sync**: `[2026-01-31 02:53:13]` - absolute time with only second precision
+
+This makes it difficult to profile wake cycles (~400ms) and debug timing-sensitive issues.
+
+## Proposed Solution
+
+Change the absolute timestamp format from:
+```
+[2026-01-31 02:53:13]
+```
+to:
+```
+[2026-01-31 02:53:13.045]
+```
+
+## Technical Approach
+
+### Synchronized Millisecond Tracking
+
+The RTC and system timer are independent clocks. To get accurate milliseconds within each RTC second, we track when the RTC was synced:
+
+1. When `rtc_set_datetime()` is called, record the system timer value
+2. On each log, calculate elapsed time since sync
+3. The ms within current second = `(elapsed_ms) % 1000`
+
+This works because both the RTC and elapsed calculation advance at 1000ms per second.
+
+### Implementation
+
+**1. Add to `Logger` class (`src/hal/logger.h`):**
+
+```cpp
+private:
+    static uint64_t rtc_sync_us_;  // System time (us) when RTC was last synced
+
+public:
+    /**
+     * @brief Call immediately after rtc_set_datetime() to sync subsecond precision
+     */
+    static void onRtcSynced() {
+        rtc_sync_us_ = to_us_since_boot(get_absolute_time());
+    }
+```
+
+**2. Update timestamp formatting:**
+
+```cpp
+if (rtc_running() && rtc_get_datetime(&dt)) {
+    uint32_t ms_in_second = 0;
+    if (rtc_sync_us_ > 0) {
+        uint64_t elapsed_us = to_us_since_boot(get_absolute_time()) - rtc_sync_us_;
+        ms_in_second = (elapsed_us / 1000) % 1000;
+    }
+    printf("[%04d-%02d-%02d %02d:%02d:%02d.%03lu] ",
+           dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec, ms_in_second);
+}
+```
+
+**3. Initialize static member (`src/hal/logger.cpp`):**
+
+```cpp
+uint64_t Logger::rtc_sync_us_ = 0;
+```
+
+**4. Update RTC set call sites to call `Logger::onRtcSynced()`:**
+
+| File | Line | Context |
+|------|------|---------|
+| `src/modes/application_mode.cpp` | ~128 | After heartbeat response sets RTC |
+| `src/modes/hub_mode.cpp` | ~512 | After receiving datetime from Raspberry Pi |
+| `src/modes/sensor_mode.cpp` | ~1061 | After receiving datetime from PMU |
+
+## Tasks
+
+- [ ] Add `rtc_sync_us_` static member and `onRtcSynced()` method to Logger
+- [ ] Update timestamp formatting to use synchronized milliseconds
+- [ ] Initialize static member in logger.cpp
+- [ ] Add `Logger::onRtcSynced()` call after `rtc_set_datetime()` in application_mode.cpp
+- [ ] Add `Logger::onRtcSynced()` call after `rtc_set_datetime()` in hub_mode.cpp
+- [ ] Add `Logger::onRtcSynced()` call after `rtc_set_datetime()` in sensor_mode.cpp
+- [ ] Build all variants to verify compilation
+- [ ] Test on hardware
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/hal/logger.h` | Add `rtc_sync_us_`, `onRtcSynced()`, update timestamp format |
+| `src/hal/logger.cpp` | Initialize `rtc_sync_us_` static member |
+| `src/modes/application_mode.cpp` | Call `Logger::onRtcSynced()` after RTC set |
+| `src/modes/hub_mode.cpp` | Call `Logger::onRtcSynced()` after RTC set |
+| `src/modes/sensor_mode.cpp` | Call `Logger::onRtcSynced()` after RTC set |
+
+## Example Output
+
+Before:
+```
+[+1234ms] INFO [SensorMode]: Starting measurement
+[+1456ms] INFO [SensorMode]: Temperature: 22.5C
+[2026-01-31 02:53:13] INFO [SensorMode]: RTC synced, sending data
+[2026-01-31 02:53:13] INFO [SensorMode]: Transmission complete
+```
+
+After:
+```
+[+1234ms] INFO [SensorMode]: Starting measurement
+[+1456ms] INFO [SensorMode]: Temperature: 22.5C
+[2026-01-31 02:53:13.045] INFO [SensorMode]: RTC synced, sending data
+[2026-01-31 02:53:13.312] INFO [SensorMode]: Transmission complete
+```

--- a/plans/read_index_transmitted_flag.md
+++ b/plans/read_index_transmitted_flag.md
@@ -1,0 +1,69 @@
+# Read Index Recovery Using Transmitted Flag
+
+## Problem
+
+On cold start, `recoverReadIndex()` tries to validate `read_index` from stale flash metadata. If invalid, it **resets read_index to write_index** — effectively declaring "nothing to read" and silently dropping all untransmitted records.
+
+The transmitted flag (`transmission_status` byte) on each record is the true source of truth for what has/hasn't been sent. We should use it to find the correct read position instead of trusting metadata alone.
+
+## Current Flow (cold start)
+
+1. `init()` loads stale flash metadata (including `read_index`)
+2. `scanForWriteIndex()` fixes `write_index` via binary search
+3. `recoverReadIndex()`:
+   - Validates `read_index` from metadata (CRC check on record at that position)
+   - If invalid → resets to `write_index` (data loss!)
+   - `fastForwardReadIndex()` advances past transmitted records
+
+## Proposed Flow
+
+After `scanForWriteIndex()` determines `write_index`, recover `read_index` by scanning for the **first valid, untransmitted record**:
+
+1. **Scan backward from `write_index`** to find the start of the untransmitted region
+   - Read only the 1-byte `transmission_status` field (efficient, no full record read)
+   - Stop when we hit a transmitted record or the beginning of data
+   - This gives us the earliest untransmitted record
+
+2. **Set `read_index`** to that position
+
+3. **During `readUntransmittedRecords()`** (already works this way):
+   - Skip records with CRC errors (corrupted)
+   - Skip records already marked as transmitted (safety net)
+   - Collect valid, untransmitted records into the output buffer
+
+## Design Details
+
+### Why scan backward from write_index?
+
+Records are written sequentially. Transmitted records are at the "old" end (near `read_index`), untransmitted at the "new" end (near `write_index`). Scanning backward from `write_index` finds the boundary efficiently — most of the time the untransmitted region is small (a few wake cycles' worth).
+
+### Why not scan forward from 0?
+
+Forward scan from 0 would work but is slower — it has to skip over potentially millions of transmitted records. Backward scan converges faster on the boundary.
+
+### Efficiency
+
+- Read only the 1-byte `transmission_status` at each index (same as `fastForwardReadIndex()`)
+- Worst case: scan all records (cold start after long offline period with no transmissions)
+- Typical case: scan a few hundred records (recent untransmitted backlog)
+
+### What about the binary search approach?
+
+We could binary search for the transmitted→untransmitted boundary, but:
+- The transmitted flag is only 1 byte read per probe, already very fast
+- The transition isn't guaranteed to be monotonic (hub may have ACK'd records out of order, or corruption could make a transmitted record look untransmitted)
+- Linear backward scan is simple, correct, and fast enough
+
+## Changes Required
+
+1. **`recoverReadIndex()`** — Replace current logic with backward scan from `write_index`
+2. **Remove `isReadIndexValid()`** — No longer needed; read_index is derived from transmitted flags
+3. **Remove `fastForwardReadIndex()`** — Subsumed by the backward scan (it finds the exact boundary directly)
+4. **`readUntransmittedRecords()`** — No changes needed (already skips transmitted + invalid)
+
+## Edge Cases
+
+- **All records transmitted**: backward scan reaches beginning of data → `read_index = write_index` (empty buffer, correct)
+- **No records transmitted**: backward scan reaches beginning of data → `read_index = 0` (all records pending, correct)
+- **Corrupted transmission_status byte**: A corrupted byte won't be exactly `0x00` (RECORD_TRANSMITTED), so the record appears untransmitted. This is safe — worst case we re-transmit, and the hub deduplicates via timestamp
+- **Buffer wrap-around**: Same limitation as `scanForWriteIndex()` — deferred until wrap is realistic

--- a/plans/state_machine_inheritance.md
+++ b/plans/state_machine_inheritance.md
@@ -1,0 +1,170 @@
+# State Machine Inheritance Refactor
+
+## Problem Statement
+
+Currently there are two independent state machines running in `SensorMode`:
+1. `BaseStateMachine` (from `ApplicationMode`) - logs as `[StateMachine]`
+2. `SensorStateMachine` (in `SensorMode`) - logs as `[SensorSM]`
+
+This causes duplicate log lines like:
+```
+[+319ms] INFO [StateMachine]: State: INITIALIZING -> AWAITING_TIME
+[+400ms] INFO [SensorSM]: State: INITIALIZING -> AWAITING_TIME
+```
+
+The design intent was for `SensorStateMachine` to inherit from `BaseStateMachine`, but they're currently separate classes with different paradigms.
+
+## Key Architectural Differences
+
+| Aspect | BaseStateMachine | SensorStateMachine |
+|--------|-----------------|-------------------|
+| **Pattern** | Hardware-polling | Event-driven |
+| **States** | 4 (INITIALIZING, AWAITING_TIME, OPERATIONAL, ERROR) | 11 (wake-cycle workflow states) |
+| **Update** | `update(BaseHardwareState)` | `reportXyz()` event methods |
+| **State derivation** | `deriveState()` virtual method | Mixed: `updateState()` + `transitionTo()` |
+
+## Design Decision
+
+**Option A: True Inheritance** - SensorStateMachine extends BaseStateMachine
+- Requires reconciling hardware-polling vs event-driven
+- Complex due to different state enums
+
+**Option B: Disable Base in SensorMode** - SensorMode skips BaseStateMachine updates
+- Simple fix but doesn't address design intent
+- Leaves dead code
+
+**Option C: State Mapping Bridge** (Recommended)
+- SensorStateMachine maps its states to BaseState equivalents
+- Notifies BaseStateMachine when base-level state changes
+- Single source of truth (SensorStateMachine), no duplicate transitions
+- ApplicationMode can still query base state if needed
+
+## Recommended Approach: Option C
+
+### Concept
+
+SensorStateMachine internally tracks the equivalent `BaseState` and can report it:
+
+```cpp
+class SensorStateMachine {
+public:
+    // Map sensor state to base state
+    BaseState baseState() const {
+        switch (state_) {
+            case SensorState::INITIALIZING:
+                return BaseState::INITIALIZING;
+            case SensorState::AWAITING_TIME:
+            case SensorState::SYNCING_TIME:
+                return BaseState::AWAITING_TIME;
+            case SensorState::ERROR:
+                return BaseState::ERROR;
+            default:  // All operational states
+                return BaseState::OPERATIONAL;
+        }
+    }
+};
+```
+
+### Changes Required
+
+#### 1. `src/util/sensor_state_machine.h`
+- Add `#include "base_state_machine.h"` for `BaseState` enum
+- Add `baseState()` method to map SensorState → BaseState
+- Add optional `BaseStateCallback` for notifying when base-level state changes
+
+#### 2. `src/util/sensor_state_machine.cpp`
+- Implement `baseState()` mapping
+- In `transitionTo()`: check if `baseState()` changed, call base callback if set
+
+#### 3. `src/modes/application_mode.h`
+- Make `state_machine_` protected (currently private) so subclasses can access
+- Or add `baseStateMachine()` accessor
+
+#### 4. `src/modes/application_mode.cpp`
+- In `run()`: check if subclass has its own state machine before calling `updateStateMachine()`
+- Or: make `updateStateMachine()` virtual so subclasses can override
+
+#### 5. `src/modes/sensor_mode.cpp`
+- Option A: Override base state machine updates to be no-op
+- Option B: Connect `sensor_state_` to notify `state_machine_` when base state changes
+- Remove duplicate state transition logging
+
+## Implementation Plan
+
+### Step 1: Add baseState() mapping to SensorStateMachine
+```cpp
+// sensor_state_machine.h
+#include "base_state_machine.h"
+
+class SensorStateMachine {
+public:
+    BaseState baseState() const;
+    // ...
+};
+
+// sensor_state_machine.cpp
+BaseState SensorStateMachine::baseState() const {
+    switch (state_) {
+        case SensorState::INITIALIZING:
+            return BaseState::INITIALIZING;
+        case SensorState::AWAITING_TIME:
+        case SensorState::SYNCING_TIME:
+            return BaseState::AWAITING_TIME;
+        case SensorState::ERROR:
+            return BaseState::ERROR;
+        default:
+            return BaseState::OPERATIONAL;
+    }
+}
+```
+
+### Step 2: Prevent duplicate BaseStateMachine transitions in SensorMode
+
+In `ApplicationMode::run()`, add a virtual method that subclasses can override:
+
+```cpp
+// application_mode.h
+protected:
+    virtual bool usesCustomStateMachine() const { return false; }
+
+// application_mode.cpp - in run()
+if (!usesCustomStateMachine()) {
+    state_machine_.markInitialized();
+    updateStateMachine();
+}
+
+// sensor_mode.h
+protected:
+    bool usesCustomStateMachine() const override { return true; }
+```
+
+### Step 3: (Optional) Bridge callback for base state changes
+
+If ApplicationMode needs to react to base-level state changes from sensor:
+
+```cpp
+// In SensorMode::onStart()
+sensor_state_.setBaseStateCallback([this](BaseState base) {
+    // Could update ApplicationMode's state_machine_ if needed
+    // Or just use for logging coordination
+});
+```
+
+## Files to Modify
+
+1. `src/util/sensor_state_machine.h` - Add baseState() method
+2. `src/util/sensor_state_machine.cpp` - Implement baseState()
+3. `src/modes/application_mode.h` - Add usesCustomStateMachine() virtual
+4. `src/modes/application_mode.cpp` - Check before base state machine init
+5. `src/modes/sensor_mode.h` - Override usesCustomStateMachine()
+
+## Verification
+
+1. Build: `/bramble-build SENSOR`
+2. Flash and observe logs - should see only `[SensorSM]` state transitions, not duplicate `[StateMachine]` lines
+3. Verify wake cycle works correctly:
+   - Boot → INITIALIZING → AWAITING_TIME (after PMU state restored)
+   - Time sync → TIME_SYNCED
+   - Sensor read → READING_SENSOR → CHECKING_BACKLOG
+   - TX if needed → TRANSMITTING → READY_FOR_SLEEP
+4. Verify `sensor_state_.baseState()` returns correct base state at each point

--- a/test_v4_blink.cpp
+++ b/test_v4_blink.cpp
@@ -1,0 +1,37 @@
+/**
+ * Minimal v4 board blink + UART test.
+ * Blinks the NeoPixel on GPIO4 between green and blue, prints to UART/USB.
+ * Board header: UART1 TX=GPIO24, RX=GPIO25 (115200 baud).
+ */
+#include "pico/stdlib.h"
+#include "hal/neopixel.h"
+#include <cstdio>
+
+int main()
+{
+    stdio_init_all();
+
+    NeoPixel led(PICO_DEFAULT_WS2812_PIN, 1);
+    led.setBrightness(32);
+
+    // Solid green while USB/UART settle
+    led.setPixel(0, 0, 255, 0);
+    led.show();
+    sleep_ms(2000);
+
+    // Blue flash to confirm we got past init
+    led.setPixel(0, 0, 0, 255);
+    led.show();
+    sleep_ms(500);
+
+    int count = 0;
+    while (true) {
+        bool on = (count % 2) == 0;
+        led.setPixel(0, 0, on ? 255 : 0, 0);
+        led.show();
+
+        printf("v4 board alive, count=%d, led=%s\n", count, on ? "GREEN" : "OFF");
+        count++;
+        sleep_ms(500);
+    }
+}


### PR DESCRIPTION
## Summary
Brings into the repo a bunch of useful project assets that have been sitting uncommitted for a while:

- **\`.claude/commands/\`** — \`commit.md\`, \`sort-tmux-panes.md\` (project slash commands).
- **\`.claude/skills/\`** — 6 skills not already in main: \`bramble-flash\`, \`bramble-hub-logs\`, \`bramble-logs\`, \`git\`, \`github-create-issue\`, \`orchestrate\`.
- **\`.gitignore\`** — ignore \`.claude/settings.local.json\` (per-user prefs).
- **\`docs/battery-life-analysis.md\`** — energy measurement writeup.
- **\`plans/\`** — five design notes: cm5_bringup, factory_reset, issue72_subsecond_timestamps, read_index_transmitted_flag, state_machine_inheritance.
- **\`test_v4_blink.cpp\`** — minimal v4 board bringup blink+UART test, kept at root as a template for v5 bringup.

## Base
Stacked on \`chore/commitlint-husky\` (#185) so the \`build_v*/\` / \`node_modules/\` / \`dashboard/.vite/\` ignores are already in place. Will rebase onto \`main\` after #185 lands.

## Test plan
- [ ] Confirm \`/bramble-flash\`, \`/bramble-hub-logs\`, \`/bramble-logs\` skills still invoke cleanly after merge.
- [ ] Confirm \`.claude/settings.local.json\` no longer shows up in \`git status\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)