### PR TITLE
fix(ci): unbreak firmware-build (V3 boot2 + WS2812 default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,18 @@ elseif(BOARD_VERSION STREQUAL "V4")
     message(STATUS "Board version: V4 (RP2350B)")
 else()
     set(PICO_BOARD adafruit_feather_rp2040 CACHE STRING "Board type" FORCE)
-    # Use W25Q boot2 - matches W25Q16JV flash chip
-    set(PICO_DEFAULT_BOOT_STAGE2_FILE ${PICO_SDK_PATH}/src/rp2040/boot_stage2/boot2_w25q080.S CACHE STRING "" FORCE)
     message(STATUS "Board version: V3 (RP2040)")
 endif()
 
-# Pull in Raspberry Pi Pico SDK (must be before project)
+# Pull in Raspberry Pi Pico SDK (must be before project).
+# This populates the PICO_SDK_PATH variable from the environment if set.
 include(pico_sdk_import.cmake)
+
+# V3 override: use W25Q boot2 - matches W25Q16JV flash chip. Must come AFTER
+# pico_sdk_import so ${PICO_SDK_PATH} is a real path, not an empty string.
+if(BOARD_VERSION STREQUAL "V3" OR NOT BOARD_VERSION)
+    set(PICO_DEFAULT_BOOT_STAGE2_FILE ${PICO_SDK_PATH}/src/rp2040/boot_stage2/boot2_w25q080.S CACHE STRING "" FORCE)
+endif()
 
 # Pull in Pico extras (if available)
 set(PICO_EXTRAS_PATH ${CMAKE_CURRENT_LIST_DIR}/pico-extras)

--- a/pmu-stm32/CMakeLists.txt
+++ b/pmu-stm32/CMakeLists.txt
@@ -58,8 +58,9 @@ target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
     # Add user defined library search paths
 )
 
-# WS2812 addressable RGB LED support (PA4, pin 10 TSSOP20, bit-banged)
-option(USE_WS2812 "Use WS2812 RGB LED instead of dual-color GPIO LED" OFF)
+# WS2812 addressable RGB LED support (PA5, bit-banged) — production uses this.
+# Disable only when bringing up a board with the legacy dual-color GPIO LED.
+option(USE_WS2812 "Use WS2812 RGB LED instead of dual-color GPIO LED" ON)
 option(PMU_BRINGUP_MODE "Keep DC/DC on and skip sleep for development" OFF)
 
 # Add sources to executable


### PR DESCRIPTION
\`main\` is currently failing the Build Firmware workflow. Two distinct regressions exposed when firmware-touching PRs landed back-to-back today:

## 1. RP2040 V3 build — boot stage 2 path empty
\`\`\`
CMake Error: Specified boot stage 2 source '/src/rp2040/boot_stage2/boot2_w25q080.S' does not exist
\`\`\`
The override at \`CMakeLists.txt:47\` referenced \`\${PICO_SDK_PATH}\` before \`include(pico_sdk_import.cmake)\` populated it from the env, so the path expanded to an absolute but bogus \`/src/rp2040/...\`. Local builds happened to have \`PICO_SDK_PATH\` cached in the build dir's \`CMakeCache\`, masking the issue. CI gets a fresh build dir every run.

**Fix**: defer the V3 boot stage 2 override until after \`include(pico_sdk_import.cmake)\`.

## 2. STM32 PMU build — LED 2-arg constructor missing
\`\`\`
note: candidate: 'LED::LED()'
note: candidate expects 0 arguments, 2 provided
\`\`\`
\`LED led(GPIOA, GPIO_PIN_5)\` in \`pmu-stm32/Core/Src/main.cpp\` requires the WS2812 variant of the LED class. The 2-arg constructor only exists inside \`#ifdef USE_WS2812\` in \`led.h\`. The CMake option defaulted to \`OFF\` so CI built the dual-color GPIO LED class (which has only \`LED()\`). Local users had \`USE_WS2812=ON\` in their build cache.

**Fix**: flip the default to \`ON\` — production hardware uses the WS2812. Boards without it (legacy bringup boards) can override with \`-DUSE_WS2812=OFF\`.

## Local verification
\`\`\`
$ cmake -B build -DHARDWARE_VARIANT=IRRIGATION   # V3 default
...
[100%] Linking CXX executable bramble_irrigation_sx1262.elf
[100%] Built target bramble_irrigation_sx1262
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)