### PR TITLE
fix(api): unbreak DuckDB init — strip line comments before splitting schema

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -226,7 +226,7 @@ class SensorDatabase:
     );
 
     -- Audit trail for ad-hoc dashboard commands (valve run/stop, curtain,
-    -- wake-interval). Schedules stay in their own table; this is the
+    -- wake-interval). Schedules stay in their own table — this is the
     -- equivalent lifecycle log for fire-and-forget commands so the user
     -- can see "pending" state during the dead zone between click and the
     -- node's confirming event.
@@ -337,8 +337,14 @@ class SensorDatabase:
         """Initialize database schema and open the persistent connection."""
         self._open_connection()
         with self._get_connection() as conn:
-            # Execute schema statements one at a time
-            for statement in self.SCHEMA.split(';'):
+            # Strip `-- ...` line comments before splitting so a `;` inside
+            # a comment doesn't break statement boundaries (it has). Block
+            # comments (/* ... */) are not used in this schema.
+            cleaned = '\n'.join(
+                line for line in self.SCHEMA.splitlines()
+                if not line.strip().startswith('--')
+            )
+            for statement in cleaned.split(';'):
                 statement = statement.strip()
                 if statement:
                     conn.execute(statement)


### PR DESCRIPTION
\`main\` API container is crash-looping on startup → dashboard 502s.

## Root cause
The new \`node_commands\` table comment I added in #181 contained a semicolon:

\`\`\`
-- wake-interval). Schedules stay in their own table; this is the
\`\`\`

\`init_db\` naively splits the schema on \`;\`, so the second half of the comment became the start of the next \"statement\". DuckDB choked:

\`\`\`
Parser Error: syntax error at or near \"this\"
LINE 1: this is the
\`\`\`

Container exits → Cloudflare 502 → dashboard can't fetch anything.

## Fix
1. Reword the comment to drop the semicolon (immediate unblock).
2. Strip \`-- ...\` line comments **before** \`split(';')\` so a stray semicolon inside a comment can never break statement boundaries again. Block comments aren't used in this schema.

## Verification
Local re-split of \`SensorDatabase.SCHEMA\` yields **18 statements**, every one starts with a real \`CREATE\`. Hub container restart should pick up the new image and recover the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)