### PR TITLE
feat(api,dashboard): record schedule add/remove in node_commands audit log

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -683,8 +683,23 @@ def add_schedule(device_id: int):
             valve=data['valve']
         )
 
-        # Queue command for delivery (uses address for hub routing)
-        from command_queue import queue_set_schedule
+        # Record in the node_commands audit log so the dashboard's Recent
+        # Activity shows a pending row immediately (mirrors valve_open flow).
+        from command_queue import queue_set_schedule, COMMAND_TTL_DEFAULTS
+
+        command_id = db.insert_command(
+            device_id=device_id,
+            command_type='schedule_set',
+            params={
+                'index': data['index'],
+                'hour': data['hour'],
+                'minute': data['minute'],
+                'duration': data['duration'],
+                'days': data['days'],
+                'valve': data['valve'],
+            },
+            ttl_seconds=COMMAND_TTL_DEFAULTS['schedule_set'],
+        )
 
         result = queue_set_schedule(
             node_address=address,
@@ -696,9 +711,13 @@ def add_schedule(device_id: int):
             valve=data['valve']
         )
 
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'device_id': str(device_id),  # String to preserve JS precision
             'address': address,
             'schedule': data,
@@ -734,14 +753,26 @@ def remove_schedule(device_id: int, index: int):
         # Remove from local schedule storage
         db.delete_schedule(device_id=device_id, index=index)
 
-        # Queue command for delivery (uses address for hub routing)
-        from command_queue import queue_remove_schedule
+        # Record in the node_commands audit log so the dashboard's Recent
+        # Activity shows a pending row immediately (mirrors valve_open flow).
+        from command_queue import queue_remove_schedule, COMMAND_TTL_DEFAULTS
+
+        command_id = db.insert_command(
+            device_id=device_id,
+            command_type='schedule_remove',
+            params={'index': index},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['schedule_remove'],
+        )
 
         result = queue_remove_schedule(node_address=address, index=index)
+
+        if command_id is not None:
+            db.set_command_huey_task(command_id, result.id)
 
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
+            'command_id': command_id,
             'device_id': str(device_id),  # String to preserve JS precision
             'address': address,
             'schedule_index': index,

--- a/api/command_queue.py
+++ b/api/command_queue.py
@@ -30,6 +30,8 @@ COMMAND_TTL_DEFAULTS = {
     'valve_close': 1800,
     'curtain': 600,
     'wake_interval': 300,
+    'schedule_set': 1800,
+    'schedule_remove': 1800,
 }
 
 

--- a/api/serial_interface.py
+++ b/api/serial_interface.py
@@ -526,6 +526,9 @@ class SerialInterface:
             # Match pending ad-hoc valve commands.
             self._reconcile_valve_event(device_id, event_type, detail, unix_ts)
 
+            # Match pending ad-hoc schedule commands.
+            self._reconcile_schedule_event(device_id, event_type, detail, unix_ts)
+
         except (ValueError, IndexError) as e:
             logger.error(f"Failed to parse EVENT_LOG: {e}")
 
@@ -555,6 +558,47 @@ class SerialInterface:
             logger.info(
                 f"Command confirmed: id={cmd['id']}, type={cmd_type}, "
                 f"valve={valve_id}, device_id={device_id}"
+            )
+
+    def _reconcile_schedule_event(self, device_id: int, event_type: int,
+                                  index: int, unix_ts: int):
+        """Confirm or fail pending schedule_set / schedule_remove commands."""
+        if event_type == EventType.SCHEDULE_APPLIED:
+            cmd_type = 'schedule_set'
+            status = 'confirmed'
+        elif event_type == EventType.SCHEDULE_REMOVED:
+            cmd_type = 'schedule_remove'
+            status = 'confirmed'
+        elif event_type == EventType.SCHEDULE_FAILED:
+            for candidate in ('schedule_set', 'schedule_remove'):
+                cmd = self.database.find_pending_command(
+                    device_id, candidate, param_filter={'index': index}
+                )
+                if cmd:
+                    self.database.update_command_status(
+                        cmd['id'], 'failed', unix_ts,
+                        event_code=event_type, event_detail=index,
+                    )
+                    logger.info(
+                        f"Command failed: id={cmd['id']}, type={candidate}, "
+                        f"index={index}, device_id={device_id}"
+                    )
+                    return
+            return
+        else:
+            return
+
+        cmd = self.database.find_pending_command(
+            device_id, cmd_type, param_filter={'index': index}
+        )
+        if cmd:
+            self.database.update_command_status(
+                cmd['id'], status, unix_ts,
+                event_code=event_type, event_detail=index,
+            )
+            logger.info(
+                f"Command confirmed: id={cmd['id']}, type={cmd_type}, "
+                f"index={index}, device_id={device_id}"
             )
 
     def _reconcile_curtain_event(self, device_id: int, event_code: int,

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -277,6 +277,8 @@ const COMMAND_VISUALS: Record<NodeCommandType, EventVisual> = {
   valve_close: EVENT_VISUALS[EventType.VALVE_CLOSE] ?? DEFAULT_VISUAL,
   curtain: { icon: ArrowUpFromLine, color: 'text-gray-600', bgColor: 'bg-gray-50' },
   wake_interval: { icon: Clock, color: 'text-gray-600', bgColor: 'bg-gray-50' },
+  schedule_set: EVENT_VISUALS[EventType.SCHEDULE_APPLIED] ?? DEFAULT_VISUAL,
+  schedule_remove: EVENT_VISUALS[EventType.SCHEDULE_REMOVED] ?? DEFAULT_VISUAL,
 };
 
 function curtainVisualForAction(action: string | undefined): EventVisual {
@@ -330,6 +332,20 @@ function commandLabel(command: NodeCommand): string {
         ? params.interval_seconds
         : null;
       return interval !== null ? `Wake Interval · ${interval}s` : 'Wake Interval';
+    }
+    case 'schedule_set': {
+      const index = typeof params.index === 'number' ? params.index : 0;
+      const hour = typeof params.hour === 'number' ? params.hour : 0;
+      const minute = typeof params.minute === 'number' ? params.minute : 0;
+      const duration = typeof params.duration === 'number' ? params.duration : null;
+      const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+      return duration !== null
+        ? `Schedule #${index} · ${time} · ${formatDuration(duration)}`
+        : `Schedule #${index} · ${time}`;
+    }
+    case 'schedule_remove': {
+      const index = typeof params.index === 'number' ? params.index : 0;
+      return `Remove Schedule #${index}`;
     }
   }
 }

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -257,7 +257,9 @@ export type NodeCommandType =
   | 'valve_open'
   | 'valve_close'
   | 'curtain'
-  | 'wake_interval';
+  | 'wake_interval'
+  | 'schedule_set'
+  | 'schedule_remove';
 
 export interface NodeCommand {
   id: number;


### PR DESCRIPTION
## Summary
- Schedule add/remove now appear immediately in the dashboard's Recent Activity as a pending command and transition to confirmed when the node TX_BATCHes back the matching event — same UX as the valve flow.
- API: \`add_schedule\` and \`remove_schedule\` write to the \`node_commands\` audit table; a new \`_reconcile_schedule_event\` matches incoming SCHEDULE_APPLIED / SCHEDULE_REMOVED / SCHEDULE_FAILED events to pending rows by schedule \`index\`.
- Dashboard: extends \`NodeCommandType\` with \`schedule_set\` / \`schedule_remove\`, plus visuals (Calendar / CalendarX) and labels.

## Why
The existing flow only updated the \`irrigation_schedules\` table on confirmation, so dashboard-issued schedule changes were invisible in Recent Activity until (and unless) the node firmware echoed the event back. The valve flow already had the right pattern via \`db.insert_command\` — this just wires schedules into the same audit log.

No DB migration required: \`node_commands.command_type\` is plain \`VARCHAR\` with no CHECK constraint.

## Test plan
- [ ] Restart API container; delete a schedule from the dashboard — pending row appears in Recent Activity within one poll cycle
- [ ] Wait for node wake — row transitions to "Confirmed · Xs"
- [ ] Add a schedule — same pending → confirmed lifecycle with the schedule time/duration in the label
- [ ] \`GET /api/nodes/<id>/schedules\` still reflects intended state immediately (irrigation_schedules table unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)