### PR TITLE
feat: surface PMU error code on SCHEDULE_FAILED events

### DIFF
--- a/api/serial_interface.py
+++ b/api/serial_interface.py
@@ -507,27 +507,43 @@ class SerialInterface:
             data_hex = f"{severity:02X}{detail:04X}"
             self.database.insert_event(device_id, unix_ts, event_type, data_hex)
 
+            # For schedule events the firmware packs the PMU error code into
+            # the high byte of `detail` and the schedule index into the low
+            # byte. APPLIED/REMOVED carry error_code=0, so detail==index for
+            # success; FAILED carries the actual ErrorCode.
+            schedule_index = detail & 0xFF
+            pmu_error_code = (detail >> 8) & 0xFF
+
             # Handle schedule confirmation events
             if event_type == EventType.SCHEDULE_APPLIED:
-                self.database.confirm_schedule(device_id, detail, unix_ts)
-                logger.info(f"Schedule confirmed: device_id={device_id}, index={detail}")
+                self.database.confirm_schedule(device_id, schedule_index, unix_ts)
+                logger.info(f"Schedule confirmed: device_id={device_id}, index={schedule_index}")
             elif event_type == EventType.SCHEDULE_REMOVED:
-                self.database.confirm_schedule_removed(device_id, detail, unix_ts)
-                logger.info(f"Schedule removal confirmed: device_id={device_id}, index={detail}")
+                self.database.confirm_schedule_removed(device_id, schedule_index, unix_ts)
+                logger.info(
+                    f"Schedule removal confirmed: device_id={device_id}, index={schedule_index}"
+                )
             elif event_type == EventType.SCHEDULE_FAILED:
-                self.database.fail_schedule(device_id, detail, unix_ts)
-                logger.info(f"Schedule failed: device_id={device_id}, index={detail}")
+                self.database.fail_schedule(device_id, schedule_index, unix_ts)
+                logger.warning(
+                    f"Schedule failed: device_id={device_id}, index={schedule_index}, "
+                    f"pmu_error=0x{pmu_error_code:02X}"
+                )
             else:
                 logger.debug(
                     f"Event log: device_id={device_id}, type=0x{event_type:02X}, "
                     f"severity={severity}, detail={detail}"
                 )
 
-            # Match pending ad-hoc valve commands.
+            # Match pending ad-hoc valve commands (still uses raw detail —
+            # valve events encode the valve id directly, not packed).
             self._reconcile_valve_event(device_id, event_type, detail, unix_ts)
 
-            # Match pending ad-hoc schedule commands.
-            self._reconcile_schedule_event(device_id, event_type, detail, unix_ts)
+            # Match pending ad-hoc schedule commands. Pass the raw `detail`
+            # so the failure path keeps the PMU error code in the audit row.
+            self._reconcile_schedule_event(
+                device_id, event_type, schedule_index, detail, unix_ts
+            )
 
         except (ValueError, IndexError) as e:
             logger.error(f"Failed to parse EVENT_LOG: {e}")
@@ -561,8 +577,13 @@ class SerialInterface:
             )
 
     def _reconcile_schedule_event(self, device_id: int, event_type: int,
-                                  index: int, unix_ts: int):
-        """Confirm or fail pending schedule_set / schedule_remove commands."""
+                                  index: int, raw_detail: int, unix_ts: int):
+        """Confirm or fail pending schedule_set / schedule_remove commands.
+
+        `raw_detail` is the full 16-bit event detail (PMU error code in the
+        high byte, schedule index in the low byte). Stored on failure so the
+        dashboard can show why the PMU rejected the schedule.
+        """
         if event_type == EventType.SCHEDULE_APPLIED:
             cmd_type = 'schedule_set'
             status = 'confirmed'
@@ -577,11 +598,12 @@ class SerialInterface:
                 if cmd:
                     self.database.update_command_status(
                         cmd['id'], 'failed', unix_ts,
-                        event_code=event_type, event_detail=index,
+                        event_code=event_type, event_detail=raw_detail,
                     )
                     logger.info(
                         f"Command failed: id={cmd['id']}, type={candidate}, "
-                        f"index={index}, device_id={device_id}"
+                        f"index={index}, pmu_error=0x{(raw_detail >> 8) & 0xFF:02X}, "
+                        f"device_id={device_id}"
                     )
                     return
             return

--- a/dashboard/src/components/RecentEvents.tsx
+++ b/dashboard/src/components/RecentEvents.tsx
@@ -33,6 +33,7 @@ import {
   getEventDetail,
   parseEventDetail,
   formatDuration,
+  getPmuErrorName,
   EventType,
   EventCode,
 } from '../types';
@@ -369,8 +370,21 @@ function commandStatusSuffix(command: NodeCommand): string {
       }
       return ' · Confirmed';
     }
-    case 'failed':
+    case 'failed': {
+      // Schedule failures pack the PMU error code into the high byte of
+      // confirming_event_detail. Surface it so the user knows why.
+      if (
+        (command.command_type === 'schedule_set' ||
+          command.command_type === 'schedule_remove') &&
+        command.confirming_event_detail != null
+      ) {
+        const errorCode = (command.confirming_event_detail >> 8) & 0xFF;
+        if (errorCode !== 0) {
+          return ` · Failed · ${getPmuErrorName(errorCode)}`;
+        }
+      }
       return ' · Failed';
+    }
     case 'expired':
       return command.command_type === 'wake_interval'
         ? ' · Sent (no confirmation available)'

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -298,6 +298,28 @@ export function parseEventDetail(dataHex: string | null | undefined): number | n
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+// PMU error codes — must match enum class ErrorCode in src/hal/pmu_protocol.h
+// and pmu-stm32/Core/Inc/pmu_protocol.h.
+export const PMU_ERROR_NAMES: Record<number, string> = {
+  0x00: 'NoError',
+  0x01: 'InvalidParam',
+  0x02: 'ScheduleFull',
+  0x03: 'InvalidIndex',
+  0x04: 'Overlap',
+  0x05: 'ChecksumError',
+};
+
+export function getPmuErrorName(code: number): string {
+  return PMU_ERROR_NAMES[code] ?? `Error 0x${code.toString(16).padStart(2, '0')}`;
+}
+
+// Schedule events pack `(pmu_error_code << 8) | index` into the 16-bit detail.
+// For APPLIED/REMOVED, error_code is always 0; for FAILED it carries the
+// reason the PMU rejected the schedule.
+export function parseScheduleDetail(detail: number): { index: number; errorCode: number } {
+  return { index: detail & 0xFF, errorCode: (detail >> 8) & 0xFF };
+}
+
 // Human-readable suffix for the event row (e.g. "Valve 1", "#3").
 // Returns null when there's nothing useful to show.
 export function getEventDetail(code: number, dataHex: string | null | undefined): string | null {
@@ -311,8 +333,11 @@ export function getEventDetail(code: number, dataHex: string | null | undefined)
       return `Valve ${detail + 1}`;
     case EventType.SCHEDULE_APPLIED:
     case EventType.SCHEDULE_REMOVED:
-    case EventType.SCHEDULE_FAILED:
-      return `#${detail}`;
+      return `#${detail & 0xFF}`;
+    case EventType.SCHEDULE_FAILED: {
+      const { index, errorCode } = parseScheduleDetail(detail);
+      return errorCode !== 0 ? `#${index} · ${getPmuErrorName(errorCode)}` : `#${index}`;
+    }
     default:
       return null;
   }

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -558,8 +558,7 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                     // Pack PMU error code into the high byte of the event detail
                     // so the dashboard can surface why the apply failed.
                     logger.error("  Failed to apply schedule: error %d", static_cast<int>(error));
-                    const uint16_t detail =
-                        (static_cast<uint16_t>(error) << 8) | index;
+                    const uint16_t detail = (static_cast<uint16_t>(error) << 8) | index;
                     event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
                 }
                 onUpdateApplied(hub_sequence);
@@ -586,8 +585,7 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                     // Pack PMU error code into the high byte of the event detail
                     // so the dashboard can surface why the remove failed.
                     logger.error("  Failed to remove schedule: error %d", static_cast<int>(error));
-                    const uint16_t detail =
-                        (static_cast<uint16_t>(error) << 8) | index;
+                    const uint16_t detail = (static_cast<uint16_t>(error) << 8) | index;
                     event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
                 }
                 onUpdateApplied(hub_sequence);

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -555,11 +555,12 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                     logger.info("  Schedule applied successfully");
                     event_log_.record(EventType::SCHEDULE_APPLIED, 0, index);
                 } else {
-                    // Treat failure as terminal — record SCHEDULE_FAILED event so the
-                    // dashboard sees it, then advance the sequence so the queue keeps
-                    // moving. The user can retry from the dashboard if needed.
+                    // Pack PMU error code into the high byte of the event detail
+                    // so the dashboard can surface why the apply failed.
                     logger.error("  Failed to apply schedule: error %d", static_cast<int>(error));
-                    event_log_.record(EventType::SCHEDULE_FAILED, 2, index);
+                    const uint16_t detail =
+                        (static_cast<uint16_t>(error) << 8) | index;
+                    event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
                 }
                 onUpdateApplied(hub_sequence);
             });
@@ -582,9 +583,12 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                     }
                     event_log_.record(EventType::SCHEDULE_REMOVED, 0, index);
                 } else {
-                    // Terminal failure — record event, advance queue.
+                    // Pack PMU error code into the high byte of the event detail
+                    // so the dashboard can surface why the remove failed.
                     logger.error("  Failed to remove schedule: error %d", static_cast<int>(error));
-                    event_log_.record(EventType::SCHEDULE_FAILED, 2, index);
+                    const uint16_t detail =
+                        (static_cast<uint16_t>(error) << 8) | index;
+                    event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
                 }
                 onUpdateApplied(hub_sequence);
             });


### PR DESCRIPTION
## Summary
- Node firmware now packs the PMU \`ErrorCode\` into the high byte of the \`SCHEDULE_FAILED\` event's \`detail\` (low byte = schedule index, unchanged).
- API extracts the index for command reconciliation and persists the raw detail on the failed \`node_commands\` row.
- Dashboard decodes the error byte and shows it in both the event row (\"Schedule Failed · #1 · Overlap\") and the failed command row (\"Schedule #1 · 13:25 · 15min · Failed · Overlap\").

## Why
Today's dashboard says \"Failed\" with no reason; the PMU \`ErrorCode\` (\`Overlap\`, \`ScheduleFull\`, \`InvalidParam\`, etc.) is only printed to the node's local serial console. Surfacing it makes failures self-diagnosable from the dashboard.

\`APPLIED\` / \`REMOVED\` events still carry \`error_code = 0\`, so detail is wire-compatible (old reconcilers reading the full \`detail\` as the index still get the right index, since the high byte is zero on success).

Sets up PR 2 — switching the PMU \`SetSchedule\` path to slot-targeted writes — by giving us a way to see whether failures are \`Overlap\` (likely, if my theory about PMU/dashboard slot drift is right) or something else.

## Test plan
- [x] Build IRRIGATION variant locally
- [ ] Flash irrigation node, restart API container
- [ ] Add an overlapping schedule from the dashboard
- [ ] Verify Recent Activity shows \`Schedule #N · ... · Failed · Overlap\` (command row) and \`Schedule Failed · #N · Overlap\` (event row)
- [ ] Verify successful add/remove still display normally (no error suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)