### PR TITLE
fix(irrigation): force-close all valves on boot

### DIFF
--- a/src/hal/valve_controller.cpp
+++ b/src/hal/valve_controller.cpp
@@ -82,6 +82,17 @@ void ValveController::closeAllValves()
     }
 }
 
+void ValveController::forceCloseAllValves()
+{
+    ensureInitialized();
+
+    log.info("Force-closing all valves...");
+
+    for (uint8_t i = 0; i < NUM_VALVES; i++) {
+        operateValve(i, false);
+    }
+}
+
 void ValveController::restoreValveState(uint8_t valve_id, ValveState state)
 {
     ensureInitialized();

--- a/src/hal/valve_controller.h
+++ b/src/hal/valve_controller.h
@@ -101,9 +101,21 @@ public:
     /**
      * @brief Close all valves
      *
-     * Useful for emergency shutoff or initialization
+     * Skips valves already known to be CLOSED. Use for runtime shutoff
+     * where the in-memory state is authoritative.
      */
     void closeAllValves();
+
+    /**
+     * @brief Force-close all valves regardless of cached state
+     *
+     * Pulses every valve's close coil unconditionally so the physical
+     * state is reconciled with the firmware's idea of CLOSED. Use at
+     * boot — the in-memory state may have been restored from PMU RAM
+     * (so closeAllValves would no-op) but the latching valves could
+     * still be mechanically open from a pre-power-loss command.
+     */
+    void forceCloseAllValves();
 
     /**
      * @brief Restore a valve's in-memory state without actuating hardware

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -112,9 +112,11 @@ void IrrigationMode::onStart()
         reliable_pmu_->clearToSend([this](bool success, PMU::ErrorCode error) {
             if (!success) {
                 pmu_logger.error("ClearToSend failed: %d", static_cast<int>(error));
-                // Proceed without PMU state — close all valves to establish known state
+                // Proceed without PMU state — force-close all valves so the
+                // physical state matches firmware's assumed CLOSED, even if
+                // the latching valves were left open before power loss.
                 event_log_.record(EventType::BOOT_COLD, 0, 0);
-                valve_controller_.closeAllValves();
+                valve_controller_.forceCloseAllValves();
                 irrigation_state_.markInitialized();
             } else {
                 pmu_logger.info("ClearToSend ACK received - waiting for WakeNotification");
@@ -124,7 +126,7 @@ void IrrigationMode::onStart()
                     [this](uint32_t) -> bool {
                         pmu_logger.warn("WakeNotification timeout - proceeding without PMU state");
                         event_log_.record(EventType::BOOT_COLD, 0, 0);
-                        valve_controller_.closeAllValves();
+                        valve_controller_.forceCloseAllValves();
                         wake_timeout_id_ = 0;
                         irrigation_state_.markInitialized();
                         return true;
@@ -134,9 +136,9 @@ void IrrigationMode::onStart()
         });
     } else {
         logger.warn("PMU client not available - running without power management");
-        // No PMU — close all valves to establish known state
+        // No PMU — force-close all valves to reconcile physical state.
         event_log_.record(EventType::BOOT_COLD, 0, 0);
-        valve_controller_.closeAllValves();
+        valve_controller_.forceCloseAllValves();
         irrigation_state_.markInitialized();
     }
 
@@ -336,10 +338,11 @@ void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEn
         event_log_.record(EventType::BOOT_COLD, 0, 0);
     }
 
-    // SSR-driven valves do not hold state across power-down — force-close on every
-    // boot so firmware state matches physical reality. For DC latching valves this
-    // is a no-op when persisted state is already CLOSED.
-    valve_controller_.closeAllValves();
+    // Force-close on every boot so firmware state matches physical reality.
+    // The PMU's persisted state can claim valves are CLOSED while the latching
+    // valves are mechanically OPEN (e.g. after a power loss mid-cycle), so
+    // we always re-issue the close pulse here rather than trust software state.
+    valve_controller_.forceCloseAllValves();
 
     // Handle valve timer wake — close the valve that was left open
     if (reason == PMU::WakeReason::ValveTimer) {


### PR DESCRIPTION
## Summary
Adds \`ValveController::forceCloseAllValves()\` that pulses every valve's close coil unconditionally, and uses it at the four boot-time sites in \`irrigation_mode.cpp\` instead of the cached-state \`closeAllValves()\`.

## Why
On a warm boot the PMU's persisted state blob is restored into the firmware (\`irrigation_mode.cpp:756\`), setting every valve's in-memory state to whatever it was before sleep — usually \`CLOSED\`. The boot's subsequent \`closeAllValves()\` call (\`irrigation_mode.cpp:342\`) then short-circuits on \`valve_states_[i] == CLOSED\` and never pulses the H-bridge — so a mechanically-open latching valve (after e.g. mid-cycle power loss) silently stays open. We confirmed this in the field: boot log says \"Closing all valves...\" but no audible click follows.

\`forceCloseAllValves()\` skips the state check and goes straight through \`operateValve(i, false)\`, which both energises the H-bridge and updates the cached state to \`CLOSED\`. Runtime callers (the \`handleScheduleComplete\` shutdown loop) keep the cached-state optimisation so we don't add unnecessary H-bridge wear during every normal sleep cycle.

## Test plan
- [x] IRRIGATION variant builds cleanly
- [ ] Flash node, reboot, listen for a click on every valve (currently silent)
- [ ] Open a valve from the dashboard, force a power cycle, reboot — should click closed
- [ ] Run a normal schedule, let it complete, observe no extra clicks at sleep handoff (runtime path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)