### PR TITLE
feat(pmu): slot-targeted SetSchedule (stable PMU schedule indices)

### DIFF
--- a/pmu-stm32/Core/Inc/pmu_protocol.h
+++ b/pmu-stm32/Core/Inc/pmu_protocol.h
@@ -156,10 +156,14 @@ public:
     // Set the persistent storage backend. Must be called before use if FRAM is available.
     void setStorage(PersistentStorage *storage) { storage_ = storage; }
 
-    // Add a schedule entry at the next available slot
-    ErrorCode addEntry(const ScheduleEntry &entry);
+    // Write a schedule entry to a specific slot, replacing whatever was
+    // there. Slot indices are stable across removes (no shifting), so the
+    // hub's "schedule N" always maps to PMU slot N. Validates the entry,
+    // checks overlap against all OTHER enabled slots, then persists.
+    ErrorCode setEntry(uint8_t index, const ScheduleEntry &entry);
 
-    // Remove entry at index (shifts subsequent entries down)
+    // Remove entry at index by clearing its enabled flag. Does NOT shift
+    // subsequent entries — slot indices stay stable.
     ErrorCode removeEntry(uint8_t index);
 
     // Clear all entries

--- a/pmu-stm32/Core/Src/pmu_protocol.cpp
+++ b/pmu-stm32/Core/Src/pmu_protocol.cpp
@@ -123,30 +123,52 @@ bool ScheduleEntry::timeRangesOverlap(uint8_t h1, uint8_t m1, uint16_t d1, uint8
 
 WateringSchedule::WateringSchedule() : storage_(nullptr) {}
 
-ErrorCode WateringSchedule::addEntry(const ScheduleEntry &entry)
+ErrorCode WateringSchedule::setEntry(uint8_t index, const ScheduleEntry &entry)
 {
     if (!storage_)
         return ErrorCode::InvalidParam;
+
+    if (index >= MAX_SCHEDULE_ENTRIES) {
+        return ErrorCode::InvalidIndex;
+    }
 
     if (!entry.isValid()) {
         return ErrorCode::InvalidParam;
     }
 
-    uint8_t count = getCount();
-    if (count >= MAX_SCHEDULE_ENTRIES) {
-        return ErrorCode::ScheduleFull;
-    }
-
-    if (hasOverlap(entry)) {
+    // Overlap check skips the destination slot itself — replacing a slot
+    // with a non-overlapping entry should succeed.
+    if (hasOverlap(entry, index)) {
         return ErrorCode::Overlap;
     }
 
-    // Write the new entry and update count
-    if (!storage_->saveScheduleEntry(count, entry)) {
+    // Count is a watermark (highest-used-slot + 1) so the existing
+    // `for i = 0; i < count` iteration covers all live slots. Disabled
+    // slots inside the watermark are skipped via the entry's enabled flag.
+    uint8_t count = getCount();
+
+    // When expanding the watermark, explicitly disable any gap slots so
+    // pre-existing FRAM data (left over from the old shift-on-remove
+    // model, or from an upgrade from earlier firmware) cannot show up as
+    // a phantom schedule.
+    if (index > count) {
+        ScheduleEntry empty;
+        empty.enabled = false;
+        for (uint8_t i = count; i < index; i++) {
+            if (!storage_->saveScheduleEntry(i, empty)) {
+                return ErrorCode::InvalidParam;
+            }
+        }
+    }
+
+    if (!storage_->saveScheduleEntry(index, entry)) {
         return ErrorCode::InvalidParam;
     }
-    if (!storage_->setScheduleCount(count + 1)) {
-        return ErrorCode::InvalidParam;
+
+    if (index + 1 > count) {
+        if (!storage_->setScheduleCount(index + 1)) {
+            return ErrorCode::InvalidParam;
+        }
     }
 
     return ErrorCode::NoError;
@@ -157,24 +179,41 @@ ErrorCode WateringSchedule::removeEntry(uint8_t index)
     if (!storage_)
         return ErrorCode::InvalidParam;
 
+    if (index >= MAX_SCHEDULE_ENTRIES) {
+        return ErrorCode::InvalidIndex;
+    }
+
     uint8_t count = getCount();
     if (index >= count) {
         return ErrorCode::InvalidIndex;
     }
 
-    // Shift entries down in FRAM
-    for (uint8_t i = index; i < count - 1; i++) {
-        ScheduleEntry entry;
-        if (!storage_->loadScheduleEntry(i + 1, entry)) {
-            return ErrorCode::InvalidParam;
-        }
-        if (!storage_->saveScheduleEntry(i, entry)) {
-            return ErrorCode::InvalidParam;
-        }
+    // Clear the slot's enabled flag in place — do NOT shift subsequent
+    // slots, so slot indices stay stable across removes.
+    ScheduleEntry entry;
+    if (!storage_->loadScheduleEntry(index, entry)) {
+        return ErrorCode::InvalidParam;
+    }
+    entry.enabled = false;
+    if (!storage_->saveScheduleEntry(index, entry)) {
+        return ErrorCode::InvalidParam;
     }
 
-    if (!storage_->setScheduleCount(count - 1)) {
-        return ErrorCode::InvalidParam;
+    // Trim trailing disabled slots from the watermark so iteration stays
+    // efficient when entries are removed from the end.
+    uint8_t newCount = count;
+    while (newCount > 0) {
+        ScheduleEntry trailing;
+        if (!storage_->loadScheduleEntry(newCount - 1, trailing))
+            break;
+        if (trailing.enabled)
+            break;
+        newCount--;
+    }
+    if (newCount != count) {
+        if (!storage_->setScheduleCount(newCount)) {
+            return ErrorCode::InvalidParam;
+        }
     }
     return ErrorCode::NoError;
 }
@@ -807,20 +846,23 @@ void Protocol::handleGetWakeInterval()
 
 void Protocol::handleSetSchedule(const uint8_t *data, uint8_t length)
 {
-    if (length != SCHEDULE_ENTRY_SIZE) {
+    // Payload is index byte followed by a 7-byte ScheduleEntry.
+    if (length != SCHEDULE_ENTRY_SIZE + 1) {
         sendNack(ErrorCode::InvalidParam);
         return;
     }
 
-    ScheduleEntry entry;
-    entry.hour = data[0];
-    entry.minute = data[1];
-    entry.duration = data[2] | (data[3] << 8);
-    entry.daysMask = static_cast<DayOfWeek>(data[4]);
-    entry.valveId = data[5];
-    entry.enabled = (data[6] != 0);
+    uint8_t index = data[0];
 
-    ErrorCode result = schedule_.addEntry(entry);
+    ScheduleEntry entry;
+    entry.hour = data[1];
+    entry.minute = data[2];
+    entry.duration = data[3] | (data[4] << 8);
+    entry.daysMask = static_cast<DayOfWeek>(data[5]);
+    entry.valveId = data[6];
+    entry.enabled = (data[7] != 0);
+
+    ErrorCode result = schedule_.setEntry(index, entry);
 
     if (result == ErrorCode::NoError) {
         sendAck();

--- a/src/hal/pmu_reliability.cpp
+++ b/src/hal/pmu_reliability.cpp
@@ -236,17 +236,21 @@ bool ReliablePmuClient::setWakeInterval(uint32_t seconds, CommandCallback callba
     return queueCommand(Command::SetWakeInterval, data, 4, callback);
 }
 
-bool ReliablePmuClient::setSchedule(const ScheduleEntry &entry, CommandCallback callback)
+bool ReliablePmuClient::setSchedule(uint8_t index, const ScheduleEntry &entry,
+                                    CommandCallback callback)
 {
-    uint8_t data[SCHEDULE_ENTRY_SIZE];
-    data[0] = entry.hour;
-    data[1] = entry.minute;
-    data[2] = entry.duration & 0xFF;
-    data[3] = (entry.duration >> 8) & 0xFF;
-    data[4] = static_cast<uint8_t>(entry.daysMask);
-    data[5] = entry.valveId;
-    data[6] = entry.enabled ? 1 : 0;
-    return queueCommand(Command::SetSchedule, data, SCHEDULE_ENTRY_SIZE, callback);
+    // Payload: index byte followed by a 7-byte ScheduleEntry. The PMU
+    // writes to the specified slot (no shifting / append-only behavior).
+    uint8_t data[SCHEDULE_ENTRY_SIZE + 1];
+    data[0] = index;
+    data[1] = entry.hour;
+    data[2] = entry.minute;
+    data[3] = entry.duration & 0xFF;
+    data[4] = (entry.duration >> 8) & 0xFF;
+    data[5] = static_cast<uint8_t>(entry.daysMask);
+    data[6] = entry.valveId;
+    data[7] = entry.enabled ? 1 : 0;
+    return queueCommand(Command::SetSchedule, data, SCHEDULE_ENTRY_SIZE + 1, callback);
 }
 
 bool ReliablePmuClient::setDateTime(const DateTime &dateTime, CommandCallback callback)

--- a/src/hal/pmu_reliability.h
+++ b/src/hal/pmu_reliability.h
@@ -85,12 +85,14 @@ public:
     bool setWakeInterval(uint32_t seconds, CommandCallback callback = nullptr);
 
     /**
-     * @brief Set a schedule entry
-     * @param entry Schedule entry to set
+     * @brief Write a schedule entry to a specific PMU slot
+     * @param index Slot index (0..MAX_SCHEDULE_ENTRIES-1) — stable across removes
+     * @param entry Schedule entry to write
      * @param callback Called when command completes (optional)
      * @return true if command queued successfully
      */
-    bool setSchedule(const ScheduleEntry &entry, CommandCallback callback = nullptr);
+    bool setSchedule(uint8_t index, const ScheduleEntry &entry,
+                     CommandCallback callback = nullptr);
 
     /**
      * @brief Set the RTC date/time

--- a/src/hal/pmu_reliability.h
+++ b/src/hal/pmu_reliability.h
@@ -91,8 +91,7 @@ public:
      * @param callback Called when command completes (optional)
      * @return true if command queued successfully
      */
-    bool setSchedule(uint8_t index, const ScheduleEntry &entry,
-                     CommandCallback callback = nullptr);
+    bool setSchedule(uint8_t index, const ScheduleEntry &entry, CommandCallback callback = nullptr);
 
     /**
      * @brief Set the RTC date/time

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -552,20 +552,21 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                         entry.hour, entry.minute, entry.valveId, entry.duration,
                         static_cast<uint8_t>(entry.daysMask));
 
-            reliable_pmu_->setSchedule(index, entry, [this, hub_sequence, index](bool success,
-                                                                                 PMU::ErrorCode error) {
-                if (success) {
-                    logger.info("  Schedule applied successfully");
-                    event_log_.record(EventType::SCHEDULE_APPLIED, 0, index);
-                } else {
-                    // Pack PMU error code into the high byte of the event detail
-                    // so the dashboard can surface why the apply failed.
-                    logger.error("  Failed to apply schedule: error %d", static_cast<int>(error));
-                    const uint16_t detail = (static_cast<uint16_t>(error) << 8) | index;
-                    event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
-                }
-                onUpdateApplied(hub_sequence);
-            });
+            reliable_pmu_->setSchedule(
+                index, entry, [this, hub_sequence, index](bool success, PMU::ErrorCode error) {
+                    if (success) {
+                        logger.info("  Schedule applied successfully");
+                        event_log_.record(EventType::SCHEDULE_APPLIED, 0, index);
+                    } else {
+                        // Pack PMU error code into the high byte of the event detail
+                        // so the dashboard can surface why the apply failed.
+                        logger.error("  Failed to apply schedule: error %d",
+                                     static_cast<int>(error));
+                        const uint16_t detail = (static_cast<uint16_t>(error) << 8) | index;
+                        event_log_.record(EventType::SCHEDULE_FAILED, 2, detail);
+                    }
+                    onUpdateApplied(hub_sequence);
+                });
             break;
         }
 

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -552,8 +552,8 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                         entry.hour, entry.minute, entry.valveId, entry.duration,
                         static_cast<uint8_t>(entry.daysMask));
 
-            reliable_pmu_->setSchedule(entry, [this, hub_sequence, index](bool success,
-                                                                          PMU::ErrorCode error) {
+            reliable_pmu_->setSchedule(index, entry, [this, hub_sequence, index](bool success,
+                                                                                 PMU::ErrorCode error) {
                 if (success) {
                     logger.info("  Schedule applied successfully");
                     event_log_.record(EventType::SCHEDULE_APPLIED, 0, index);


### PR DESCRIPTION
**Supersedes #191** (auto-closed when its stacked base merged). Now rebased onto main.

## Summary
- PMU's \`SetSchedule\` becomes slot-targeted: hub now sends \`index + 7-byte entry\` (was 7 bytes, no index) and the PMU writes that specific FRAM slot.
- \`WateringSchedule::addEntry\` → \`setEntry(index, entry)\` (writes the slot, validates, overlap-checks against all OTHER enabled slots).
- \`WateringSchedule::removeEntry\` no longer shifts subsequent slots — clears the slot's \`enabled\` flag in place.
- Node \`ReliablePmuClient::setSchedule\` takes an \`index\` and packs an 8-byte payload.
- \`irrigation_mode.cpp\` passes the index through.

## Why
The dashboard's "schedule index N" was a fiction:
1. PMU \`handleSetSchedule\` always appended via \`addEntry\` regardless of what index the hub wanted.
2. \`removeEntry\` shifted subsequent slots down.

So after a remove+add cycle the PMU's actual slot contents drifted from the dashboard's per-index view, causing spurious \`Overlap\` and phantom-entry failures on later adds (which we saw in the field — see #190's debug context).

After this PR the PMU's slot 0..7 maps 1:1 with the dashboard's schedule index, removes are non-destructive to neighbouring indices, and overlap checks are computed against the actual live set.

## Migration / compatibility
- **Wire protocol change**: \`SetSchedule\` payload size 7 → 8 bytes. PMU + node firmware MUST be flashed together.
- **FRAM compatibility**: \`setEntry\` explicitly disables any gap slots between the old count watermark and the new index, defending against stale \`enabled=true\` flags left in higher slots by the old shift-on-remove model. No FRAM format version bump needed — existing schedules at slots \`[0, count)\` are preserved.

## Test plan
- [x] RP2040 \`cmake --build build_all -j8\` (ALL variants link cleanly on rebased branch)
- [ ] **User must build + flash STM32 PMU** (\`cube-cmake --build build/Debug\` in \`pmu-stm32/\`, then ST-Link). Per CLAUDE.md I can't drive the STM32 toolchain.
- [ ] After PMU flash: add schedule at index 1 with no schedule at index 0 — should succeed, PMU slot 1 written.
- [ ] Remove schedule at index 0 — index 1 must remain intact (the original bug).
- [ ] Add overlapping schedule at index 2 — should fail with \`Overlap\` and dashboard should display \`· Overlap\` via #190's error-code packing.
- [ ] Reproduce the original symptom (remove+re-add same index with different days) — must now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)