### PR TITLE
fix(irrigation): prefer PMU state address over flash on wake

### DIFF
--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -744,12 +744,14 @@ bool IrrigationMode::unpackState(const IrrigationPersistedState *persisted)
     // Restore LoRa sequence number
     messenger_.setNextSeqNum(persisted->next_seq_num);
 
-    // Restore assigned address from PMU RAM — but don't overwrite a freshly registered address
-    // (main.cpp registration runs before onStart, so the messenger may already have a valid
-    // address)
-    uint16_t current_address = messenger_.getNodeAddress();
-    if (current_address == ADDRESS_UNREGISTERED &&
-        persisted->assigned_address != ADDRESS_UNREGISTERED) {
+    // Restore assigned address from PMU RAM. The PMU state is the
+    // authoritative record of the most recently re-registered address —
+    // packState saves it on every sleep, so a non-UNREGISTERED value here
+    // always reflects a more recent registration than what main.cpp loaded
+    // from flash. Prefer it unconditionally; otherwise, after a hub-side
+    // DELETE_NODE + re-register, the flash-loaded (stale) address would win
+    // and force a re-register on every wake.
+    if (persisted->assigned_address != ADDRESS_UNREGISTERED) {
         messenger_.setNodeAddress(persisted->assigned_address);
     }
 


### PR DESCRIPTION
## Summary
\`IrrigationMode::unpackState\` was guarding the PMU-state address restore behind \`current_address == ADDRESS_UNREGISTERED\`. Once main.cpp had loaded any address from flash, the PMU state's (more recent) address was discarded — even though packState faithfully saves it on every sleep. Drop the guard so PMU state always wins.

## Why
Hit in the field after a hub-side \`DELETE_NODE 3\` to clear a stuck pending update. Sequence:

1. Flash had old address \`0x0003\`. \`DELETE_NODE 3\` wipes the hub's registration.
2. Node boots, main.cpp sets \`current_address = 0x0003\` from flash.
3. PMU state restore reads \`addr=0x0004\` (correctly persisted from packState last sleep) — guard rejects it because \`current_address != UNREGISTERED\`.
4. Node heartbeats from \`0x0003\`. Hub doesn't recognise it, flags \`PENDING_FLAG_REREGISTER\`.
5. Node re-registers, gets \`0x0004\` again; \`update_state_.current_sequence\` is reset to 0.
6. Sleeps with \`addr=0x0004\` in PMU state.
7. Wakes → step 2. Loop forever.

Side effect: because the per-wake re-register resets \`update_sequence\` to 0, any hub-queued update (e.g. \`SET_SCHEDULE\`) sits undelivered forever — \`CHECK_UPDATES\` from the node arrives with \`node_seq=0\` and the hub responds \`has_update=0\`.

\`sensor_pmu_manager.cpp:295\` already does the right thing (unconditional restore); this brings irrigation in line.

## Test plan
- [x] IRRIGATION variant builds cleanly
- [ ] Flash node, watch heartbeats stabilise on the post-re-register address (no flapping between flash and re-registered values)
- [ ] Verify a hub-queued \`SET_SCHEDULE\` lands as \`SCHEDULE_APPLIED\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)