### PR TITLE
fix(irrigation): process expired deadlines before arming PMU timer

### DIFF
--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -829,6 +829,14 @@ void IrrigationMode::armNextValveTimer()
         return;
     }
 
+    // Process any expired deadlines first. handlePmuWake calls this too,
+    // but at boot it runs before time sync (getUnixTimestamp() == 0) and
+    // returns without clearing stale slots. By the time we get here we're
+    // past time sync, so re-running it closes any expired deadlines and
+    // empties their slots — preventing a 1-second re-arm loop on
+    // restored-but-already-elapsed deadlines.
+    processExpiredValveDeadlines();
+
     uint32_t deadline = 0;
     uint8_t valve = soonestValveDeadline(deadline);
     if (valve == 0xFF) {
@@ -842,7 +850,9 @@ void IrrigationMode::armNextValveTimer()
     uint32_t seconds;
     if (now == 0 || deadline <= now) {
         // No valid wall time, or deadline already past — fire ASAP so the
-        // queue processor on the next wake closes it.
+        // queue processor on the next wake closes it. (The processExpired
+        // call above will have closed it if time was valid, so this branch
+        // only triggers in the truly-no-time-yet case.)
         seconds = 1;
     } else {
         uint32_t delta = deadline - now;


### PR DESCRIPTION
## Summary
Re-run \`processExpiredValveDeadlines\` at the top of \`armNextValveTimer\` so stale deadlines from a restored state blob get cleared once wall-clock time is available.

## Why
Field-observed 1-second re-wake loop after merging #195. Trace:

\`\`\`
[+918ms] Restored state: ... pending_close_mask=0x01   ← stale deadline
[+931ms] Force-closing all valves...                    ← physical close
... heartbeat → time sync ...
01:49:27.953 Pending valve close needs PMU timer setup - entering VALVE_ACTIVE
01:49:27.975 Arming valve timer: valve=0 seconds=1      ← arms 1-second alarm
01:49:28.301 ReadyForSleep
~8s later: same cycle, seconds=1 again, forever
\`\`\`

Root cause: \`handlePmuWake\` calls \`processExpiredValveDeadlines\` before time sync. \`getUnixTimestamp()\` returns 0 at that point and the helper bails without clearing. By the time \`armNextValveTimer\` runs (after the heartbeat → time-sync path), the deadline is past, the \"deadline <= now\" branch clamps to \`seconds = 1\`, and the loop is born.

## Fix
Idempotently re-run \`processExpiredValveDeadlines\` at the start of \`armNextValveTimer\`. Time is valid by the time anything calls this from the operational path, so the expired slot gets closed + zeroed; the queue is then either empty (no arm) or has a genuinely-future deadline.

## Test plan
- [x] IRRIGATION builds
- [ ] Flash, watch boot — should no longer loop. Restored stale deadline should close on first wake after time sync, queue empties, no \`Arming valve timer\` line, node sleeps for the normal periodic interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)