### PR TITLE
fix(irrigation): valve GPIO fix + force-close on power-on/NRST reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,23 @@ else()
         message(STATUS "Building IRRIGATION variant")
     endif()
 
+    # Standalone valve sweep test (bench bring-up, no LoRa/PMU)
+    if(HARDWARE_VARIANT STREQUAL "VALVETEST")
+        add_executable(bramble_valvetest${BOARD_SUFFIX}${RADIO_SUFFIX}
+            valve_test.cpp
+            src/hal/valve_controller.cpp
+            src/hal/hbridge.cpp
+            src/hal/valve_indexer.cpp
+            ${COMMON_SOURCES}
+        )
+        target_compile_definitions(bramble_valvetest${BOARD_SUFFIX}${RADIO_SUFFIX} PRIVATE
+            HARDWARE_IRRIGATION=1
+            DEFAULT_IS_HUB=0
+        )
+        list(APPEND BUILD_TARGETS bramble_valvetest${BOARD_SUFFIX}${RADIO_SUFFIX})
+        message(STATUS "Building VALVETEST variant")
+    endif()
+
     if(HARDWARE_VARIANT STREQUAL "ALL" OR HARDWARE_VARIANT STREQUAL "CONTROLLER")
         add_executable(bramble_controller${BOARD_SUFFIX}${RADIO_SUFFIX}
             main.cpp

--- a/pmu-stm32/Core/Inc/pmu_protocol.h
+++ b/pmu-stm32/Core/Inc/pmu_protocol.h
@@ -325,6 +325,12 @@ public:
     // Set callback for valve timer alarm configuration
     void setValveTimerCallback(SetValveTimerCallback callback) { setValveTimer_ = callback; }
 
+    // Flag that this PMU reset was a power-on (PORRSTF) or NRST-button press
+    // (PINRSTF). The flag is reported to the RP2040 in the wake notification so it
+    // force-closes valves to a known state, and is cleared once the node completes a
+    // wake cycle (ReadyForSleep). Set from main() right after reading RCC_CSR.
+    void setValveResetPending(bool pending) { valveResetPending_ = pending; }
+
     // Persistent storage integration
     void setStorage(PersistentStorage *storage);
     void loadFromStorage();
@@ -352,6 +358,11 @@ private:
     // state_valid_ is false after power-on reset (cold start detection)
     uint8_t nodeState_[NODE_STATE_SIZE];
     bool nodeStateValid_;
+
+    // One-shot: true when this PMU boot was a power-on / NRST-button reset. Reported
+    // in the wake notification so the RP2040 force-closes valves; cleared on the
+    // node's first successful ReadyForSleep.
+    bool valveResetPending_;
 
     // Clear-to-send flag - set from UART ISR, read from main loop
     volatile bool clearToSendReceived_;

--- a/pmu-stm32/Core/Src/main.cpp
+++ b/pmu-stm32/Core/Src/main.cpp
@@ -151,6 +151,14 @@ int main(void)
     HAL_Init();
 
     /* USER CODE BEGIN Init */
+    // Capture why the PMU reset before anything else can clear the flags. A power-on
+    // (PORRSTF) or NRST-button press (PINRSTF) is treated as a deliberate request to
+    // force-close all valves to a known state; a software reset (reboot/factory cmd)
+    // or watchdog reset is a warm restart that preserves valve state. Note: a power-on
+    // also asserts PINRSTF, but both map to "reset valves" so the OR is fine.
+    bool valveResetFromReset = (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST) != RESET) ||
+                               (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST) != RESET);
+    __HAL_RCC_CLEAR_RESET_FLAGS();
 
     /* USER CODE END Init */
 
@@ -198,6 +206,10 @@ int main(void)
 
     // Load persisted state from FRAM (wake interval, schedules, node state)
     protocol.loadFromStorage();
+
+    // Tell the protocol whether this boot was a power-on / NRST-button reset, so the
+    // next wake notification asks the node to force-close valves (one-shot).
+    protocol.setValveResetPending(valveResetFromReset);
 
     // Initialize DC/DC converter
     dcdc.init();

--- a/pmu-stm32/Core/Src/pmu_protocol.cpp
+++ b/pmu-stm32/Core/Src/pmu_protocol.cpp
@@ -517,7 +517,7 @@ Protocol::Protocol(UartSendCallback uartSend, SetWakeCallback setWake, KeepAwake
                    ReadyForSleepCallback readyForSleep, GetTickCallback getTick)
     : wakeInterval_(60), nextSeqNum_(SEQ_STM32_MIN), currentSeqNum_(0), uartSend_(uartSend),
       setWake_(setWake), keepAwake_(keepAwake), readyForSleep_(readyForSleep), getTick_(getTick),
-      seenIndex_(0), nodeStateValid_(false), clearToSendReceived_(false),
+      seenIndex_(0), nodeStateValid_(false), valveResetPending_(false), clearToSendReceived_(false),
       pendingMessageReady_(false), pendingSeqNum_(0), pendingCommand_(static_cast<Command>(0)),
       pendingDataLen_(0), pendingMessageDropCount_(0), storage_(nullptr)
 {
@@ -748,6 +748,8 @@ void Protocol::sendWakeNotification(WakeReason reason)
     for (uint8_t i = 0; i < NODE_STATE_SIZE; i++) {
         builder_.addByte(nodeState_[i]);
     }
+    // Valve-reset flag follows the state blob (force valves closed on power-on / NRST)
+    builder_.addByte(valveResetPending_ ? 0x01 : 0x00);
     sendMessage();
 }
 
@@ -760,7 +762,9 @@ void Protocol::sendWakeNotificationWithSchedule(WakeReason reason, const Schedul
     for (uint8_t i = 0; i < NODE_STATE_SIZE; i++) {
         builder_.addByte(nodeState_[i]);
     }
-    // Add schedule entry after state blob
+    // Valve-reset flag follows the state blob, before the schedule entry
+    builder_.addByte(valveResetPending_ ? 0x01 : 0x00);
+    // Add schedule entry after valve-reset flag
     if (entry) {
         builder_.addScheduleEntry(*entry);
     }
@@ -980,6 +984,10 @@ void Protocol::handleReadyForSleep(const uint8_t *data, uint8_t length)
         }
     }
     // If no state blob, keep previous state (backward compatibility)
+
+    // The node has received the wake notification and completed a full cycle, so a
+    // pending valve-reset has been delivered and acted on — clear the one-shot.
+    valveResetPending_ = false;
 
     // RP2040 signals it's done with work and ready for power down
     // Send ACK first, then call the callback

--- a/src/board/bramble_v4_pins.h
+++ b/src/board/bramble_v4_pins.h
@@ -120,11 +120,17 @@ constexpr uint8_t PIN_MOTOR_HI_1 = J7::PIN_10;  // GPIO 36
 constexpr uint8_t PIN_MOTOR_HI_2 = J7::PIN_8;   // GPIO 38
 constexpr uint8_t PIN_MOTOR_LO_1 = J7::PIN_6;   // GPIO 40
 constexpr uint8_t PIN_MOTOR_LO_2 = J7::PIN_4;   // GPIO 42
+// IMPORTANT: these are *silicon* GPIO numbers (what gpio_put() drives), NOT the
+// schematic net labels. The RP2350B sheet names these nets "GPIO37/39/43/41",
+// but those nets physically land on pads GPIO29/31/41/43 — verified against the
+// pad column in rp2040.kicad_sch and on the bench. Using the net-label numbers
+// (the old J7 aliases) left VALVE_2 driving an unconnected pin, and swapped
+// VALVE_3/VALVE_4.
 constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
-    J7::PIN_9,  // VALVE_1 = GPIO 37
-    J7::PIN_7,  // VALVE_2 = GPIO 39
-    J7::PIN_3,  // VALVE_3 = GPIO 43
-    J7::PIN_5,  // VALVE_4 = GPIO 41
+    29,  // VALVE_1 = silicon GPIO29
+    31,  // VALVE_2 = silicon GPIO31
+    41,  // VALVE_3 = silicon GPIO41
+    43,  // VALVE_4 = silicon GPIO43
 };
 
 // --- Curtain motor pins (greenhouse variant, J7 header) ---

--- a/src/board/bramble_v5_pins.h
+++ b/src/board/bramble_v5_pins.h
@@ -115,11 +115,17 @@ constexpr uint8_t PIN_MOTOR_HI_1 = J7::PIN_10;  // GPIO 36
 constexpr uint8_t PIN_MOTOR_HI_2 = J7::PIN_8;   // GPIO 38
 constexpr uint8_t PIN_MOTOR_LO_1 = J7::PIN_6;   // GPIO 40
 constexpr uint8_t PIN_MOTOR_LO_2 = J7::PIN_4;   // GPIO 42
+// IMPORTANT: these are *silicon* GPIO numbers (what gpio_put() drives), NOT the
+// schematic net labels. The RP2350B sheet names these nets "GPIO37/39/43/41",
+// but those nets physically land on pads GPIO29/31/41/43 — verified against the
+// pad column in rp2040.kicad_sch and on the bench. Using the net-label numbers
+// (the old J7 aliases) left VALVE_2 driving an unconnected pin, and swapped
+// VALVE_3/VALVE_4.
 constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
-    J7::PIN_9,  // VALVE_1 = GPIO 37
-    J7::PIN_7,  // VALVE_2 = GPIO 39
-    J7::PIN_3,  // VALVE_3 = GPIO 43
-    J7::PIN_5,  // VALVE_4 = GPIO 41
+    37,  // VALVE_1 = silicon GPIO37
+    39,  // VALVE_2 = silicon GPIO39
+    41,  // VALVE_3 = silicon GPIO41
+    43,  // VALVE_4 = silicon GPIO43
 };
 
 // --- Curtain motor pins (greenhouse variant, J7 header) ---

--- a/src/hal/pmu_protocol.cpp
+++ b/src/hal/pmu_protocol.cpp
@@ -498,12 +498,13 @@ void Protocol::handleWakeNotification(const uint8_t *data, uint8_t length)
     WakeReason reason = static_cast<WakeReason>(data[0]);
     log.debug("WakeReason=%d", static_cast<int>(reason));
 
-    // New format: [reason, state_valid, state[32], optional schedule_entry...]
+    // New format: [reason, state_valid, state[32], valve_reset, optional schedule_entry...]
     // Old format fallback: [reason] or [reason, schedule_entry...]
-    // Minimum new format length: 1 (reason) + 1 (state_valid) + 32 (state) = 34 bytes
+    // Minimum state-blob length: 1 (reason) + 1 (state_valid) + 32 (state) = 34 bytes
     static constexpr uint8_t MIN_NEW_FORMAT_LEN = 1 + 1 + NODE_STATE_SIZE;
 
     bool state_valid = false;
+    bool valve_reset = false;
     static uint8_t state_blob[NODE_STATE_SIZE];
     memset(state_blob, 0, NODE_STATE_SIZE);
 
@@ -515,6 +516,14 @@ void Protocol::handleWakeNotification(const uint8_t *data, uint8_t length)
         memcpy(state_blob, &data[2], NODE_STATE_SIZE);
         schedule_offset = MIN_NEW_FORMAT_LEN;  // Schedule starts after state blob
         log.debug("State valid=%d", state_valid);
+
+        // valve_reset flag follows the blob (newer PMU firmware). Absent on older
+        // firmware, in which case it defaults to false.
+        if (length >= MIN_NEW_FORMAT_LEN + 1) {
+            valve_reset = (data[MIN_NEW_FORMAT_LEN] != 0);
+            schedule_offset = MIN_NEW_FORMAT_LEN + 1;
+            log.debug("Valve reset=%d", valve_reset);
+        }
     }
 
     // Parse schedule entry data (sent with scheduled wake events)
@@ -528,11 +537,11 @@ void Protocol::handleWakeNotification(const uint8_t *data, uint8_t length)
         entry.valveId = data[schedule_offset + 5];
         entry.enabled = (data[schedule_offset + 6] != 0);
         log.debug("ValveId=%d", entry.valveId);
-        wakeNotificationCallback_(reason, &entry, state_valid, state_blob);
+        wakeNotificationCallback_(reason, &entry, state_valid, state_blob, valve_reset);
         log.debug("Callback done");
     } else {
         // Periodic or external wake (no schedule data)
-        wakeNotificationCallback_(reason, nullptr, state_valid, state_blob);
+        wakeNotificationCallback_(reason, nullptr, state_valid, state_blob, valve_reset);
     }
 }
 

--- a/src/hal/pmu_protocol.h
+++ b/src/hal/pmu_protocol.h
@@ -224,8 +224,12 @@ using UartSendCallback = std::function<void(const uint8_t *data, uint8_t length)
 // Wake notification includes state blob from PMU (stored in PMU RAM across sleep cycles)
 // state_valid: false on cold start (PMU reset), true if state was preserved
 // state: 32-byte opaque blob, only meaningful when state_valid is true
+// valve_reset: one-shot flag set on the first wake after a PMU power-on (PORRSTF) or
+//   NRST-button reset (PINRSTF). When true, valves should be force-closed to a known
+//   state even if the state blob is otherwise valid.
 using WakeNotificationCallback = std::function<void(WakeReason reason, const ScheduleEntry *entry,
-                                                    bool state_valid, const uint8_t *state)>;
+                                                    bool state_valid, const uint8_t *state,
+                                                    bool valve_reset)>;
 using ScheduleCompleteCallback = std::function<void()>;
 using CommandResultCallback = std::function<void(bool success, ErrorCode error)>;
 using WakeIntervalCallback = std::function<void(uint32_t seconds)>;

--- a/src/hal/pmu_reliability.cpp
+++ b/src/hal/pmu_reliability.cpp
@@ -41,9 +41,10 @@ bool ReliablePmuClient::init()
 
     // Forward event callbacks to protocol
     client_->getProtocol().onWakeNotification([this](WakeReason reason, const ScheduleEntry *entry,
-                                                     bool state_valid, const uint8_t *state) {
+                                                     bool state_valid, const uint8_t *state,
+                                                     bool valve_reset) {
         if (wakeCallback_) {
-            wakeCallback_(reason, entry, state_valid, state);
+            wakeCallback_(reason, entry, state_valid, state, valve_reset);
         }
     });
 

--- a/src/hal/pmu_reliability.h
+++ b/src/hal/pmu_reliability.h
@@ -35,9 +35,11 @@ using CommandCallback = std::function<void(bool success, ErrorCode error)>;
  * @param entry Schedule entry if wake was scheduled (may be nullptr)
  * @param state_valid true if state blob is valid (false on cold start)
  * @param state 32-byte opaque state blob stored in PMU RAM across sleep cycles
+ * @param valve_reset one-shot flag set on the first wake after a PMU power-on or
+ *        NRST-button reset; when true, valves should be force-closed to a known state
  */
 using WakeCallback = std::function<void(WakeReason reason, const ScheduleEntry *entry,
-                                        bool state_valid, const uint8_t *state)>;
+                                        bool state_valid, const uint8_t *state, bool valve_reset)>;
 
 /**
  * @brief Reliable PMU client with automatic retry

--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -52,7 +52,7 @@ void GreenhouseMode::onStart()
 
         // Register wake notification callback (plumbing for future scheduled curtain operations)
         pmu_client_->getProtocol().onWakeNotification(
-            [](PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool, const uint8_t *) {
+            [](PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool, const uint8_t *, bool) {
                 if (reason == PMU::WakeReason::Scheduled && entry) {
                     pmu_logger.info("Scheduled wake: hour=%d min=%d duration=%ds", entry->hour,
                                     entry->minute, entry->duration);

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -101,8 +101,8 @@ void IrrigationMode::onStart()
 
         // Set up PMU callback handlers
         reliable_pmu_->onWake([this](PMU::WakeReason reason, const PMU::ScheduleEntry *entry,
-                                     bool state_valid, const uint8_t *state) {
-            this->handlePmuWake(reason, entry, state_valid, state);
+                                     bool state_valid, const uint8_t *state, bool valve_reset) {
+            this->handlePmuWake(reason, entry, state_valid, state, valve_reset);
         });
 
         reliable_pmu_->onScheduleComplete([this]() { this->handleScheduleComplete(); });
@@ -301,7 +301,7 @@ void IrrigationMode::scheduleKeepAwake()
 }
 
 void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEntry *entry,
-                                   bool state_valid, const uint8_t *state)
+                                   bool state_valid, const uint8_t *state, bool valve_reset)
 {
     // Cancel the wake notification timeout — PMU responded
     if (wake_timeout_id_ != 0) {
@@ -327,11 +327,19 @@ void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEn
         event_log_.record(EventType::BOOT_COLD, 0, 0);
     }
 
-    // Force-close on every boot so firmware state matches physical reality.
+    // Reset valves to a known-closed state only on a genuine cold start (no valid
+    // persisted state) or a deliberate reset (PMU power-on / NRST-button press,
+    // signalled by valve_reset). On a warm reboot (RP2040 reset, watchdog, crash,
+    // normal wake) we trust the restored state so in-progress irrigation survives.
     // The PMU's persisted state can claim valves are CLOSED while the latching
-    // valves are mechanically OPEN (e.g. after a power loss mid-cycle), so
-    // we always re-issue the close pulse here rather than trust software state.
-    valve_controller_.forceCloseAllValves();
+    // valves are mechanically OPEN (e.g. power loss mid-cycle); the deliberate
+    // reset path is how the operator forces physical reconciliation.
+    if (!restored || valve_reset) {
+        valve_controller_.forceCloseAllValves();
+        for (uint8_t i = 0; i < ValveController::NUM_VALVES; i++) {
+            valve_close_deadlines_[i] = 0;
+        }
+    }
 
     // Process the per-valve deadline queue: close every valve whose
     // deadline has passed. This handles both ValveTimer wakes (the alarm

--- a/src/modes/irrigation_mode.h
+++ b/src/modes/irrigation_mode.h
@@ -82,7 +82,7 @@ private:
 
     // PMU callback handlers
     void handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool state_valid,
-                       const uint8_t *state);
+                       const uint8_t *state, bool valve_reset);
     void handleScheduleComplete();
 
     // Registration handling

--- a/src/util/sensor_pmu_manager.cpp
+++ b/src/util/sensor_pmu_manager.cpp
@@ -54,9 +54,10 @@ bool SensorPmuManager::initialize(InitCallback init_callback)
     pmu_logger.info("PMU client initialized successfully");
 
     // Set up PMU callback handler - this receives state and completes initialization
-    reliable_pmu_->onWake(
-        [this](PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool state_valid,
-               const uint8_t *state) { this->handlePmuWake(reason, entry, state_valid, state); });
+    reliable_pmu_->onWake([this](PMU::WakeReason reason, const PMU::ScheduleEntry *entry,
+                                 bool state_valid, const uint8_t *state, bool /*valve_reset*/) {
+        this->handlePmuWake(reason, entry, state_valid, state);
+    });
 
     // Signal ready to receive wake info - PMU will respond with wake notification
     // containing persisted state (write_index, read_index, etc.)

--- a/valve_test.cpp
+++ b/valve_test.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file valve_test.cpp
+ * @brief Standalone valve sweep test for irrigation hardware bring-up.
+ *
+ * Opens each valve in turn for 5 seconds, then closes it before moving on
+ * to the next: valve 0 ON (5s) -> OFF, valve 1 ON (5s) -> OFF, ...
+ * After the last valve it loops back to the first.
+ *
+ * Intended for probing the valve drive path with a DMM — no LoRa, PMU, or
+ * hub registration so it never blocks on the bench.
+ *
+ * Build:  cmake -B build -DHARDWARE_VARIANT=VALVETEST -DBOARD_VERSION=V4
+ */
+#include "pico/stdlib.h"
+
+#include "hal/logger.h"
+#include "hal/valve_controller.h"  // transitively provides Board:: pin map
+
+namespace {
+constexpr uint32_t VALVE_ON_DURATION_MS = 5000;
+constexpr uint32_t INTER_VALVE_PAUSE_MS = 1000;
+Logger logger("VALVETEST");
+}  // namespace
+
+int main()
+{
+    stdio_init_all();
+
+    // Give USB/UART a moment to settle so the first logs are visible.
+    sleep_ms(2000);
+
+    logger.info("=== VALVE SWEEP TEST ===");
+    logger.info("Sweeping %d valves, %lu ms each", ValveController::NUM_VALVES,
+                static_cast<unsigned long>(VALVE_ON_DURATION_MS));
+
+    // Print the full pin map so the bench observation can be correlated to silicon
+    // GPIOs. Each valve id selects one VALVE_PINS line; the shared H-bridge then
+    // pulses FORWARD (open) or REVERSE (close).
+    logger.info("H-bridge: HI_1=%u LO_1=%u HI_2=%u LO_2=%u (FORWARD=HI_1+LO_2, REVERSE=HI_2+LO_1)",
+                Board::PIN_MOTOR_HI_1, Board::PIN_MOTOR_LO_1, Board::PIN_MOTOR_HI_2,
+                Board::PIN_MOTOR_LO_2);
+    for (uint8_t i = 0; i < ValveController::NUM_VALVES; i++) {
+        logger.info("  id %u -> select GPIO %u", i, Board::VALVE_PINS[i]);
+    }
+
+    ValveController valve_controller;
+    valve_controller.initialize();
+
+    // Start from a known state — all valves closed.
+    valve_controller.forceCloseAllValves();
+
+    while (true) {
+        for (uint8_t valve_id = 0; valve_id < ValveController::NUM_VALVES; valve_id++) {
+            logger.info(">>> id %u (select GPIO %u) -> OPEN  — note which PHYSICAL valve moves",
+                        valve_id, Board::VALVE_PINS[valve_id]);
+            valve_controller.openValve(valve_id);
+
+            sleep_ms(VALVE_ON_DURATION_MS);
+
+            logger.info("<<< id %u (select GPIO %u) -> CLOSE", valve_id,
+                        Board::VALVE_PINS[valve_id]);
+            valve_controller.closeValve(valve_id);
+
+            sleep_ms(INTER_VALVE_PAUSE_MS);
+        }
+        logger.info("Sweep complete — restarting");
+    }
+}


### PR DESCRIPTION
## Summary

Three related fixes for the irrigation node, found during valve bring-up:

- **VALVETEST bench harness** (`86f67f4`) — standalone valve sweep test (no LoRa/PMU/hub) for probing the drive path with a DMM on the bench.
- **Valve GPIO fix** (`e805fb0`) — `VALVE_PINS` used the J7 net-label aliases, which land on different silicon pads: valve 2 drove an unconnected pin and valves 3/4 were swapped, so valves 1 & 2 never actuated. Now points at the real silicon GPIOs (verified on the bench).
- **Valve-reset-on-boot** (`4440477`) — PMU latches a one-shot flag on power-on (PORRSTF) / NRST-button reset and reports it in the wake notification; the RP2040 force-closes valves only on a genuine cold start or that deliberate reset, instead of on every boot. Warm reboots/watchdog/normal wakes now preserve in-progress irrigation.

## ⚠️ Deploy note

The wake notification gains a byte (valve-reset flag after the state blob). Older RP2040 firmware tolerates it (length-guarded, defaults false), but to get the new behavior **both the PMU (STM32) and the node firmware must be reflashed**, and the **hub** needs updating.

## Test

- `VALVETEST` builds for V5/SX1262 and the valve sweep confirmed valves 1–4 actuate after the GPIO fix.
- Power-on/NRST → force-close; warm reboot → state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)