### PR TITLE
fix(dashboard): build Node stage on native arch to avoid QEMU hang

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -2,7 +2,12 @@
 # Produces a lightweight nginx image serving the built SPA
 
 # Stage 1: Build the React application
-FROM node:20-alpine AS build
+# Pin the build stage to the runner's NATIVE arch ($BUILDPLATFORM) so the Node/vite
+# compile runs natively instead of under QEMU emulation for each target platform. The
+# emitted dist/ is static and arch-independent, so only the nginx stage below needs to
+# be built per-target-arch. Without this, the emulated arm64 npm build hangs/crawls for
+# 30+ minutes on every deploy.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The dashboard `docker-build` job wedged at **67 minutes** on a deploy. Root cause: the Dockerfile build stage runs `npm ci && npm run build` under the **target** platform, so the `linux/arm64` image compiles the SPA under QEMU emulation — the classic Node/esbuild-under-QEMU hang/crawl.

## Fix

Pin the build stage to `$BUILDPLATFORM` so the Node/vite compile always runs natively on the amd64 runner. The emitted `dist/` is static and architecture-independent, so only the lightweight nginx stage is built per-target-arch.

```dockerfile
FROM --platform=$BUILDPLATFORM node:20-alpine AS build
```

Cuts the dashboard build from tens of minutes back to ~1–2 min, permanently.

## Context

Follow-up to #198 (valve-count). The API already deployed fine; this unblocks the dashboard half. The previous wedged run was cancelled/superseded by this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)