### PR TITLE
feat: valve groups (master valve)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -9,7 +9,10 @@ from typing import Optional
 from config import Config
 from serial_interface import SerialInterface
 from database import SensorDatabase
-from models import Node, NodeMetadata, Schedule, QueuedUpdate, Zone, format_firmware_version
+from models import (Node, NodeMetadata, Schedule, QueuedUpdate, Zone,
+                    MAX_SCHEDULE_SLOTS, format_firmware_version)
+from valve_groups import (compute_master_windows, diff_master_slots,
+                          MasterSlotOverflow)
 
 
 # Setup logging
@@ -223,6 +226,134 @@ def _node_valve_count(device_id: int) -> int:
         logger.warning(f"DB valve-count lookup failed for device_id {device_id}: {e}")
 
     return LEGACY_VALVE_COUNT
+
+
+# --- Valve group (master valve) helpers ---
+
+def _gather_member_schedules(db, members, override=None):
+    """Collect zone schedules for all group members, filtered to each member's
+    valve.
+
+    `override` simulates a not-yet-persisted change for overflow pre-checks:
+    {'device_id': int, 'index': int, 'schedule': dict|None} where schedule None
+    means a deletion. A schedule is uniquely (device_id, index).
+    """
+    member_valves = {}
+    for member in members:
+        member_valves.setdefault(int(member['zone_device_id']), set()).add(
+            member['zone_valve'])
+    result = []
+    for device_id, valves in member_valves.items():
+        rows = {s['index']: s for s in db.get_schedules(device_id)}
+        if override and override['device_id'] == device_id:
+            if override['schedule'] is None:
+                rows.pop(override['index'], None)
+            else:
+                rows[override['index']] = override['schedule']
+        result.extend(s for s in rows.values() if s['valve'] in valves)
+    return result
+
+
+def _apply_master_diff(db, group, force=False):
+    """Recompute a group's master node schedules and queue the minimal diff.
+
+    Mirrors each zone window onto the master node. With force=True every owned
+    slot is re-sent regardless of the diff (used by /resync to recover from a
+    TTL-expired command). Returns a summary dict. Raises MasterSlotOverflow.
+    """
+    from command_queue import (queue_set_schedule, queue_remove_schedule,
+                               COMMAND_TTL_DEFAULTS)
+    master_device_id = int(group['master_device_id'])
+    master_valve = group['master_valve']
+    master_address = _resolve_node_address(master_device_id)
+
+    member_schedules = _gather_member_schedules(db, group['members'])
+    desired = compute_master_windows(member_schedules, master_valve)
+    stored = db.list_master_slots(master_device_id)
+    diff = diff_master_slots(desired, stored, group['id'])
+    if force:
+        diff['to_set'] = list(diff['slots'])
+
+    if master_address is None:
+        # Persist intent so a later /resync (once the master is reachable) syncs.
+        db.replace_master_slots(group['id'], master_device_id, diff['slots'])
+        logger.warning(f"Master device {master_device_id} address unknown; "
+                       f"stored slots but skipped queueing")
+        return {'set': 0, 'removed': 0, 'master_unreachable': True}
+
+    for slot in diff['to_set']:
+        cmd_id = db.insert_command(
+            device_id=master_device_id, command_type='schedule_set',
+            params={'index': slot['master_index'], 'hour': slot['hour'],
+                    'minute': slot['minute'], 'duration': slot['duration'],
+                    'days': slot['days'], 'valve': master_valve,
+                    'mirrored_from_group': group['id']},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['schedule_set'])
+        result = queue_set_schedule(
+            node_address=master_address, index=slot['master_index'],
+            hour=slot['hour'], minute=slot['minute'], duration=slot['duration'],
+            days=slot['days'], valve=master_valve)
+        if cmd_id is not None:
+            db.set_command_huey_task(cmd_id, result.id)
+
+    for index in diff['to_remove']:
+        cmd_id = db.insert_command(
+            device_id=master_device_id, command_type='schedule_remove',
+            params={'index': index, 'mirrored_from_group': group['id']},
+            ttl_seconds=COMMAND_TTL_DEFAULTS['schedule_remove'])
+        result = queue_remove_schedule(node_address=master_address, index=index)
+        if cmd_id is not None:
+            db.set_command_huey_task(cmd_id, result.id)
+
+    db.replace_master_slots(group['id'], master_device_id, diff['slots'])
+    return {'set': len(diff['to_set']), 'removed': len(diff['to_remove']),
+            'master_unreachable': False}
+
+
+def _teardown_master_slots(db, group):
+    """Queue REMOVE_SCHEDULE for every master slot the API owns for this group
+    and clear them. Used before re-homing or deleting a group."""
+    from command_queue import queue_remove_schedule, COMMAND_TTL_DEFAULTS
+    master_device_id = int(group['master_device_id'])
+    master_address = _resolve_node_address(master_device_id)
+    owned = [s for s in db.list_master_slots(master_device_id)
+             if s['group_id'] == group['id']]
+    if master_address is not None:
+        for slot in owned:
+            cmd_id = db.insert_command(
+                device_id=master_device_id, command_type='schedule_remove',
+                params={'index': slot['master_index'],
+                        'mirrored_from_group': group['id']},
+                ttl_seconds=COMMAND_TTL_DEFAULTS['schedule_remove'])
+            result = queue_remove_schedule(node_address=master_address,
+                                           index=slot['master_index'])
+            if cmd_id is not None:
+                db.set_command_huey_task(cmd_id, result.id)
+    db.replace_master_slots(group['id'], master_device_id, [])
+
+
+def _queue_master_actuator(db, group, command, duration_seconds=0):
+    """Mirror a manual valve run/stop onto the group's master valve."""
+    from command_queue import queue_send_actuator, COMMAND_TTL_DEFAULTS
+    master_device_id = int(group['master_device_id'])
+    master_valve = group['master_valve']
+    master_address = _resolve_node_address(master_device_id)
+    if master_address is None:
+        logger.warning(f"Master device {master_device_id} address unknown; "
+                       f"skipping mirror actuator")
+        return
+    cmd_type = 'valve_open' if command == 1 else 'valve_close'
+    params = {'valve': master_valve, 'mirrored_from_group': group['id']}
+    if duration_seconds:
+        params['duration_seconds'] = duration_seconds
+    cmd_id = db.insert_command(device_id=master_device_id, command_type=cmd_type,
+                               params=params,
+                               ttl_seconds=COMMAND_TTL_DEFAULTS[cmd_type])
+    result = queue_send_actuator(node_address=master_address, actuator_type=1,
+                                 command=command, param=master_valve,
+                                 duration_seconds=duration_seconds)
+    if cmd_id is not None:
+        db.set_command_huey_task(cmd_id, result.id)
 
 
 @app.route('/api/nodes', methods=['GET'])
@@ -724,6 +855,23 @@ def add_schedule(device_id: int):
         if errors:
             return jsonify({'error': 'Validation failed', 'details': errors}), 400
 
+        # If this zone valve belongs to a master-valve group, confirm the
+        # resulting master schedule set still fits BEFORE persisting anything
+        # (atomic: a slot overflow rejects the request, nothing is stored).
+        group = db.get_group_for_zone_valve(device_id, data['valve'])
+        if group:
+            prospective = _gather_member_schedules(
+                db, group['members'],
+                override={'device_id': device_id, 'index': data['index'],
+                          'schedule': {'index': data['index'], 'hour': data['hour'],
+                                       'minute': data['minute'],
+                                       'duration': data['duration'],
+                                       'days': data['days'], 'valve': data['valve']}})
+            try:
+                compute_master_windows(prospective, group['master_valve'])
+            except MasterSlotOverflow as e:
+                return jsonify({'error': f'Master valve schedule full: {e}'}), 409
+
         # Persist schedule locally so GET /schedules returns intended state
         db.store_schedule(
             device_id=device_id,
@@ -766,6 +914,10 @@ def add_schedule(device_id: int):
         if command_id is not None:
             db.set_command_huey_task(command_id, result.id)
 
+        # Mirror the resulting window set onto the group's master valve.
+        if group:
+            _apply_master_diff(db, group)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
@@ -793,14 +945,19 @@ def remove_schedule(device_id: int, index: int):
         JSON response with task_id for tracking (202 Accepted)
     """
     try:
-        if not 0 <= index <= 7:
-            return jsonify({'error': 'Schedule index must be 0-7'}), 400
+        if not 0 <= index < MAX_SCHEDULE_SLOTS:
+            return jsonify({'error': f'Schedule index must be 0-{MAX_SCHEDULE_SLOTS - 1}'}), 400
 
         address = _resolve_node_address(device_id)
         if address is None:
             return jsonify({'error': f'Node with device_id {device_id} not found'}), 404
 
         db = get_database()
+
+        # Note which valve this schedule controlled so we can recompute the
+        # master mirror after deletion (removal can only shrink the master set).
+        existing = next((s for s in db.get_schedules(device_id)
+                         if s['index'] == index), None)
 
         # Remove from local schedule storage
         db.delete_schedule(device_id=device_id, index=index)
@@ -820,6 +977,12 @@ def remove_schedule(device_id: int, index: int):
 
         if command_id is not None:
             db.set_command_huey_task(command_id, result.id)
+
+        # Recompute the master mirror if this valve was in a group.
+        if existing:
+            group = db.get_group_for_zone_valve(device_id, existing['valve'])
+            if group:
+                _apply_master_diff(db, group)
 
         return jsonify({
             'status': 'queued',
@@ -930,6 +1093,13 @@ def run_valve(device_id: int):
         if command_id is not None:
             db.set_command_huey_task(command_id, result.id)
 
+        # Mirror the run onto the group's master valve (same duration so both
+        # auto-close together).
+        group = db.get_group_for_zone_valve(device_id, valve)
+        if group:
+            _queue_master_actuator(db, group, command=1,
+                                   duration_seconds=duration_seconds)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
@@ -994,6 +1164,11 @@ def stop_valve(device_id: int):
         if command_id is not None:
             db.set_command_huey_task(command_id, result.id)
 
+        # Mirror the stop onto the group's master valve.
+        group = db.get_group_for_zone_valve(device_id, valve)
+        if group:
+            _queue_master_actuator(db, group, command=0)
+
         return jsonify({
             'status': 'queued',
             'task_id': result.id,
@@ -1006,6 +1181,216 @@ def stop_valve(device_id: int):
 
     except Exception as e:
         logger.error(f"Error stopping valve for node {device_id}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+def _validate_group_fields(db, master_device_id, master_valve, members):
+    """Return an error string if master/members are invalid, else None."""
+    master_count = _node_valve_count(master_device_id)
+    if not isinstance(master_valve, int) or not 0 <= master_valve < master_count:
+        return f'master_valve must be 0..{master_count - 1}'
+    seen = set()
+    for member in members:
+        try:
+            zone_device_id = int(member['zone_device_id'])
+            zone_valve = int(member['zone_valve'])
+        except (KeyError, TypeError, ValueError):
+            return 'each member needs zone_device_id and zone_valve'
+        if (zone_device_id, zone_valve) == (master_device_id, master_valve):
+            return 'the master valve cannot also be a zone member'
+        if (zone_device_id, zone_valve) in seen:
+            return 'duplicate member'
+        seen.add((zone_device_id, zone_valve))
+        zone_count = _node_valve_count(zone_device_id)
+        if not 0 <= zone_valve < zone_count:
+            return (f'zone_valve {zone_valve} out of range for device '
+                    f'{zone_device_id} (0..{zone_count - 1})')
+    return None
+
+
+def _check_group_uniqueness(db, master_device_id, master_valve, members,
+                            exclude_group_id=None):
+    """Return a (message, status) tuple if a uniqueness rule is violated, else None.
+
+    A zone valve may belong to at most one group; a master valve backs at most
+    one group.
+    """
+    for group in db.get_all_valve_groups():
+        if group['id'] == exclude_group_id:
+            continue
+        if (int(group['master_device_id']) == master_device_id
+                and group['master_valve'] == master_valve):
+            return (f"master valve {master_valve} on device {master_device_id} "
+                    f"already backs group '{group['name']}'", 409)
+    for member in members:
+        existing = db.get_group_for_zone_valve(int(member['zone_device_id']),
+                                               int(member['zone_valve']))
+        if existing and existing['id'] != exclude_group_id:
+            return (f"zone valve {member['zone_valve']} on device "
+                    f"{member['zone_device_id']} is already in group "
+                    f"'{existing['name']}'", 409)
+    return None
+
+
+@app.route('/api/valve-groups', methods=['GET'])
+def list_valve_groups():
+    """List all valve groups."""
+    try:
+        db = get_database()
+        groups = db.get_all_valve_groups()
+        return jsonify({'count': len(groups), 'groups': groups})
+    except Exception as e:
+        logger.error(f"Error listing valve groups: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/valve-groups', methods=['POST'])
+def create_valve_group():
+    """Create a valve group and mirror members' existing schedules to the master.
+
+    Request body:
+        {
+            "name": "Front beds",
+            "master_device_id": "123...",
+            "master_valve": 3,
+            "members": [{"zone_device_id": "456...", "zone_valve": 0}, ...]
+        }
+    """
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({'error': 'Request body must be JSON'}), 400
+        name = data.get('name')
+        if not name:
+            return jsonify({'error': 'name is required'}), 400
+        if data.get('master_device_id') is None or data.get('master_valve') is None:
+            return jsonify({'error': 'master_device_id and master_valve are required'}), 400
+        master_device_id = int(data['master_device_id'])
+        master_valve = int(data['master_valve'])
+        members = data.get('members', []) or []
+
+        db = get_database()
+        err = _validate_group_fields(db, master_device_id, master_valve, members)
+        if err:
+            return jsonify({'error': err}), 400
+        conflict = _check_group_uniqueness(db, master_device_id, master_valve, members)
+        if conflict:
+            return jsonify({'error': conflict[0]}), conflict[1]
+
+        group = db.create_valve_group(name, master_device_id, master_valve, members)
+
+        # Backfill: mirror members' existing schedules onto the master valve.
+        try:
+            _apply_master_diff(db, group)
+        except MasterSlotOverflow as e:
+            db.delete_valve_group(group['id'])
+            return jsonify({'error': f'Master valve schedule full: {e}'}), 409
+
+        return jsonify(group), 201
+    except Exception as e:
+        logger.error(f"Error creating valve group: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/valve-groups/<int:group_id>', methods=['GET'])
+def get_valve_group(group_id: int):
+    """Get a valve group by ID."""
+    try:
+        db = get_database()
+        group = db.get_valve_group(group_id)
+        if group:
+            return jsonify(group)
+        return jsonify({'error': f'Valve group {group_id} not found'}), 404
+    except Exception as e:
+        logger.error(f"Error getting valve group {group_id}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/valve-groups/<int:group_id>', methods=['PUT'])
+def update_valve_group(group_id: int):
+    """Update a valve group's name, master valve, or membership."""
+    try:
+        db = get_database()
+        old = db.get_valve_group(group_id)
+        if not old:
+            return jsonify({'error': f'Valve group {group_id} not found'}), 404
+
+        data = request.get_json()
+        if not data:
+            return jsonify({'error': 'Request body must be JSON'}), 400
+
+        name = data.get('name')
+        master_device_id = (int(data['master_device_id'])
+                            if data.get('master_device_id') is not None
+                            else int(old['master_device_id']))
+        master_valve = (int(data['master_valve'])
+                        if data.get('master_valve') is not None
+                        else old['master_valve'])
+        members = data.get('members')
+        effective_members = members if members is not None else old['members']
+
+        err = _validate_group_fields(db, master_device_id, master_valve,
+                                     effective_members)
+        if err:
+            return jsonify({'error': err}), 400
+        conflict = _check_group_uniqueness(db, master_device_id, master_valve,
+                                           effective_members,
+                                           exclude_group_id=group_id)
+        if conflict:
+            return jsonify({'error': conflict[0]}), conflict[1]
+
+        # If the master valve/node moved, tear down the old master's slots first.
+        master_moved = (int(old['master_device_id']) != master_device_id
+                        or old['master_valve'] != master_valve)
+        if master_moved:
+            _teardown_master_slots(db, old)
+
+        updated = db.update_valve_group(
+            group_id, name=name, master_device_id=master_device_id,
+            master_valve=master_valve, members=members)
+
+        try:
+            _apply_master_diff(db, updated)
+        except MasterSlotOverflow as e:
+            return jsonify({'error': f'Master valve schedule full: {e}'}), 409
+
+        return jsonify(updated)
+    except Exception as e:
+        logger.error(f"Error updating valve group {group_id}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/valve-groups/<int:group_id>', methods=['DELETE'])
+def delete_valve_group(group_id: int):
+    """Delete a valve group; removes its mirrored master schedules."""
+    try:
+        db = get_database()
+        group = db.get_valve_group(group_id)
+        if not group:
+            return jsonify({'error': f'Valve group {group_id} not found'}), 404
+        _teardown_master_slots(db, group)
+        db.delete_valve_group(group_id)
+        return jsonify({'status': 'deleted', 'id': group_id})
+    except Exception as e:
+        logger.error(f"Error deleting valve group {group_id}: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/valve-groups/<int:group_id>/resync', methods=['POST'])
+def resync_valve_group(group_id: int):
+    """Force re-push of the group's master schedules (recover from TTL expiry)."""
+    try:
+        db = get_database()
+        group = db.get_valve_group(group_id)
+        if not group:
+            return jsonify({'error': f'Valve group {group_id} not found'}), 404
+        try:
+            summary = _apply_master_diff(db, group, force=True)
+        except MasterSlotOverflow as e:
+            return jsonify({'error': f'Master valve schedule full: {e}'}), 409
+        return jsonify({'status': 'resynced', 'id': group_id, **summary})
+    except Exception as e:
+        logger.error(f"Error resyncing valve group {group_id}: {e}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/api/database.py
+++ b/api/database.py
@@ -250,6 +250,44 @@ class SensorDatabase:
 
     CREATE INDEX IF NOT EXISTS idx_cmds_pending_match
         ON node_commands(device_id, status, command_type);
+
+    -- Valve groups (master valve). A group links N zone valves to one master
+    -- valve on a (usually different) node. The API mirrors each zone window
+    -- onto the master node as its own schedule; these tables are the source of
+    -- truth, valve_group_master_slots tracking which master slots the API owns.
+    CREATE TABLE IF NOT EXISTS valve_groups (
+        id INTEGER PRIMARY KEY,
+        name VARCHAR NOT NULL,
+        master_device_id UBIGINT NOT NULL,
+        master_valve INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE (master_device_id, master_valve)
+    );
+
+    CREATE TABLE IF NOT EXISTS valve_group_members (
+        group_id INTEGER NOT NULL,
+        zone_device_id UBIGINT NOT NULL,
+        zone_valve INTEGER NOT NULL,
+        PRIMARY KEY (zone_device_id, zone_valve)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_vgm_group
+        ON valve_group_members(group_id);
+
+    CREATE TABLE IF NOT EXISTS valve_group_master_slots (
+        group_id INTEGER NOT NULL,
+        master_device_id UBIGINT NOT NULL,
+        master_index INTEGER NOT NULL,
+        hour INTEGER NOT NULL,
+        minute INTEGER NOT NULL,
+        duration INTEGER NOT NULL,
+        days INTEGER NOT NULL,
+        PRIMARY KEY (master_device_id, master_index)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_vgms_group
+        ON valve_group_master_slots(group_id);
     """
 
     def __init__(self, db_path: str = Config.SENSOR_DB_PATH):
@@ -1120,6 +1158,172 @@ class SensorDatabase:
 
             return True
 
+    # --- Valve groups (master valve) ---
+
+    def _valve_group_row(self, conn, group_id: int) -> Optional[dict]:
+        """Build a valve-group dict (with members) from an open cursor."""
+        row = conn.execute("""
+            SELECT id, name, master_device_id, master_valve, created_at, updated_at
+            FROM valve_groups WHERE id = ?
+        """, (group_id,)).fetchone()
+        if not row:
+            return None
+        members = conn.execute("""
+            SELECT zone_device_id, zone_valve FROM valve_group_members
+            WHERE group_id = ? ORDER BY zone_device_id, zone_valve
+        """, (group_id,)).fetchall()
+        return {
+            'id': row[0],
+            'name': row[1],
+            'master_device_id': str(row[2]),  # String to preserve JS precision
+            'master_valve': row[3],
+            'created_at': row[4],
+            'updated_at': row[5],
+            'members': [
+                {'zone_device_id': str(m[0]), 'zone_valve': m[1]} for m in members
+            ],
+        }
+
+    def create_valve_group(self, name: str, master_device_id: int, master_valve: int,
+                           members: list[dict]) -> dict:
+        """Create a valve group with its zone members.
+
+        Args:
+            name: Human-readable group name
+            master_device_id: Device ID of the node holding the master valve
+            master_valve: Valve index of the master valve on that node
+            members: List of {'zone_device_id': int, 'zone_valve': int}
+
+        Returns:
+            Created group dict. Raises duckdb.Error on constraint violation
+            (master already in use, or a zone valve already in another group).
+        """
+        now = int(time.time())
+        with self._get_connection() as conn:
+            next_id = conn.execute(
+                "SELECT COALESCE(MAX(id), 0) + 1 FROM valve_groups"
+            ).fetchone()[0]
+            conn.execute("""
+                INSERT INTO valve_groups
+                    (id, name, master_device_id, master_valve, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (next_id, name, master_device_id, master_valve, now, now))
+            for member in members:
+                conn.execute("""
+                    INSERT INTO valve_group_members (group_id, zone_device_id, zone_valve)
+                    VALUES (?, ?, ?)
+                """, (next_id, int(member['zone_device_id']), int(member['zone_valve'])))
+            return self._valve_group_row(conn, next_id)
+
+    def get_valve_group(self, group_id: int) -> Optional[dict]:
+        """Get a valve group (with members) by ID, or None."""
+        with self._get_connection() as conn:
+            return self._valve_group_row(conn, group_id)
+
+    def get_all_valve_groups(self) -> list[dict]:
+        """Get all valve groups (with members)."""
+        with self._get_connection() as conn:
+            ids = conn.execute("SELECT id FROM valve_groups ORDER BY name").fetchall()
+            return [self._valve_group_row(conn, row[0]) for row in ids]
+
+    def update_valve_group(self, group_id: int, name: Optional[str] = None,
+                           master_device_id: Optional[int] = None,
+                           master_valve: Optional[int] = None,
+                           members: Optional[list[dict]] = None) -> Optional[dict]:
+        """Update a valve group. Pass members to replace the membership wholesale.
+
+        Returns the updated group dict, or None if it does not exist.
+        """
+        now = int(time.time())
+        with self._get_connection() as conn:
+            existing = conn.execute(
+                "SELECT name, master_device_id, master_valve FROM valve_groups WHERE id = ?",
+                (group_id,)
+            ).fetchone()
+            if not existing:
+                return None
+            new_name = name if name is not None else existing[0]
+            new_master_device = master_device_id if master_device_id is not None else existing[1]
+            new_master_valve = master_valve if master_valve is not None else existing[2]
+            conn.execute("""
+                UPDATE valve_groups
+                SET name = ?, master_device_id = ?, master_valve = ?, updated_at = ?
+                WHERE id = ?
+            """, (new_name, new_master_device, new_master_valve, now, group_id))
+            if members is not None:
+                conn.execute("DELETE FROM valve_group_members WHERE group_id = ?", (group_id,))
+                for member in members:
+                    conn.execute("""
+                        INSERT INTO valve_group_members (group_id, zone_device_id, zone_valve)
+                        VALUES (?, ?, ?)
+                    """, (group_id, int(member['zone_device_id']), int(member['zone_valve'])))
+            return self._valve_group_row(conn, group_id)
+
+    def delete_valve_group(self, group_id: int) -> bool:
+        """Delete a valve group and its members + owned master slots.
+
+        Returns True if the group existed. The caller is responsible for
+        queueing REMOVE_SCHEDULE for the master slots before calling this.
+        """
+        with self._get_connection() as conn:
+            existing = conn.execute(
+                "SELECT id FROM valve_groups WHERE id = ?", (group_id,)
+            ).fetchone()
+            if not existing:
+                return False
+            conn.execute("DELETE FROM valve_group_members WHERE group_id = ?", (group_id,))
+            conn.execute("DELETE FROM valve_group_master_slots WHERE group_id = ?", (group_id,))
+            conn.execute("DELETE FROM valve_groups WHERE id = ?", (group_id,))
+            return True
+
+    def get_group_for_zone_valve(self, zone_device_id: int,
+                                 zone_valve: int) -> Optional[dict]:
+        """Return the group (with members) a given zone valve belongs to, or None."""
+        with self._get_connection() as conn:
+            row = conn.execute("""
+                SELECT group_id FROM valve_group_members
+                WHERE zone_device_id = ? AND zone_valve = ?
+            """, (zone_device_id, zone_valve)).fetchone()
+            if not row:
+                return None
+            return self._valve_group_row(conn, row[0])
+
+    def list_master_slots(self, master_device_id: int) -> list[dict]:
+        """List the master schedule slots the API currently owns for a master node."""
+        with self._get_connection() as conn:
+            rows = conn.execute("""
+                SELECT group_id, master_index, hour, minute, duration, days
+                FROM valve_group_master_slots
+                WHERE master_device_id = ?
+                ORDER BY master_index
+            """, (master_device_id,)).fetchall()
+            return [{
+                'group_id': r[0],
+                'master_index': r[1],
+                'hour': r[2],
+                'minute': r[3],
+                'duration': r[4],
+                'days': r[5],
+            } for r in rows]
+
+    def replace_master_slots(self, group_id: int, master_device_id: int,
+                             slots: list[dict]) -> None:
+        """Replace the stored master slots for a group with the given set.
+
+        Each slot is {'master_index', 'hour', 'minute', 'duration', 'days'}.
+        Call AFTER computing the SET/REMOVE diff against the previous slots.
+        """
+        with self._get_connection() as conn:
+            conn.execute(
+                "DELETE FROM valve_group_master_slots WHERE group_id = ?", (group_id,))
+            for slot in slots:
+                conn.execute("""
+                    INSERT INTO valve_group_master_slots
+                        (group_id, master_device_id, master_index, hour, minute, duration, days)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, (group_id, master_device_id, slot['master_index'], slot['hour'],
+                      slot['minute'], slot['duration'], slot['days']))
+
     def set_node_zone(self, device_id: int, zone_id: Optional[int]) -> Optional[dict]:
         """Set a node's zone.
 
@@ -1364,6 +1568,15 @@ class SensorDatabase:
             conn.execute("DELETE FROM node_status WHERE device_id = ?", (device_id,))
             conn.execute("DELETE FROM node_metadata WHERE device_id = ?", (device_id,))
             conn.execute("DELETE FROM irrigation_schedules WHERE device_id = ?", (device_id,))
+            # Valve groups: drop this node's zone memberships, and any group it
+            # was the master of (plus that group's members and owned slots).
+            conn.execute("DELETE FROM valve_group_members WHERE zone_device_id = ?", (device_id,))
+            conn.execute(
+                "DELETE FROM valve_group_members WHERE group_id IN "
+                "(SELECT id FROM valve_groups WHERE master_device_id = ?)", (device_id,))
+            conn.execute(
+                "DELETE FROM valve_group_master_slots WHERE master_device_id = ?", (device_id,))
+            conn.execute("DELETE FROM valve_groups WHERE master_device_id = ?", (device_id,))
             conn.execute("DELETE FROM nodes WHERE device_id = ?", (device_id,))
 
             logger.info(f"Deleted node with device_id {device_id} and all associated data")

--- a/api/models.py
+++ b/api/models.py
@@ -2,6 +2,12 @@
 from dataclasses import dataclass
 from typing import Optional
 
+# Number of on-node schedule slots (must match the PMU firmware constant
+# MAX_SCHEDULE_ENTRIES in pmu-stm32/Core/Inc/pmu_protocol.h). The dashboard
+# reserves the top index for one-shot "run now" use; persistent schedules use
+# 0..MAX_SCHEDULE_SLOTS-2.
+MAX_SCHEDULE_SLOTS = 100
+
 
 def format_firmware_version(raw_version: int) -> str:
     """Format a raw uint32 firmware version as a human-readable string.
@@ -113,8 +119,8 @@ class Schedule:
         """Validate schedule parameters."""
         errors = []
 
-        if not 0 <= self.index <= 7:
-            errors.append("index must be 0-7")
+        if not 0 <= self.index < MAX_SCHEDULE_SLOTS:
+            errors.append(f"index must be 0-{MAX_SCHEDULE_SLOTS - 1}")
         if not 0 <= self.hour <= 23:
             errors.append("hour must be 0-23")
         if not 0 <= self.minute <= 59:

--- a/api/tests/test_valve_groups_api.py
+++ b/api/tests/test_valve_groups_api.py
@@ -1,0 +1,104 @@
+"""Endpoint tests for valve-group CRUD.
+
+Serial-dependent helpers (_node_valve_count, _resolve_node_address) are patched
+so the tests don't touch the hub. With the master address unresolved, the mirror
+engine stores intent without queueing, which is exactly what we want to assert
+the HTTP wiring in isolation.
+"""
+import pytest
+
+MASTER = "1111111111111111"
+ZONE_A = "2222222222222222"
+ZONE_B = "3333333333333333"
+
+
+@pytest.fixture
+def groups_client(app_client, monkeypatch):
+    import app as flask_app
+    monkeypatch.setattr(flask_app, '_node_valve_count', lambda device_id: 4)
+    monkeypatch.setattr(flask_app, '_resolve_node_address', lambda device_id: None)
+    # The mirror/queue helpers are covered by the engine + DB tests; stub them so
+    # these endpoint tests exercise only the HTTP + DB wiring (and don't pull in
+    # huey's sqlite store).
+    monkeypatch.setattr(flask_app, '_apply_master_diff',
+                        lambda db, group, force=False: {'set': 0, 'removed': 0,
+                                                        'master_unreachable': True})
+    monkeypatch.setattr(flask_app, '_teardown_master_slots', lambda db, group: None)
+    monkeypatch.setattr(flask_app, '_queue_master_actuator',
+                        lambda db, group, command, duration_seconds=0: None)
+    return app_client
+
+
+def _create(client, name='G', master=MASTER, master_valve=3, members=None):
+    if members is None:
+        members = [{'zone_device_id': ZONE_A, 'zone_valve': 0}]
+    return client.post('/api/valve-groups', json={
+        'name': name, 'master_device_id': master,
+        'master_valve': master_valve, 'members': members})
+
+
+class TestValveGroupApi:
+    def test_create_and_get(self, groups_client):
+        resp = _create(groups_client)
+        assert resp.status_code == 201
+        group = resp.get_json()
+        assert group['name'] == 'G'
+        assert group['master_device_id'] == MASTER
+        assert group['members'] == [{'zone_device_id': ZONE_A, 'zone_valve': 0}]
+
+        got = groups_client.get(f"/api/valve-groups/{group['id']}")
+        assert got.status_code == 200
+        assert got.get_json()['id'] == group['id']
+
+    def test_list(self, groups_client):
+        _create(groups_client, name='G1', master_valve=3,
+                members=[{'zone_device_id': ZONE_A, 'zone_valve': 0}])
+        _create(groups_client, name='G2', master=ZONE_B, master_valve=0,
+                members=[{'zone_device_id': ZONE_A, 'zone_valve': 1}])
+        resp = groups_client.get('/api/valve-groups')
+        assert resp.status_code == 200
+        assert resp.get_json()['count'] == 2
+
+    def test_master_valve_out_of_range_rejected(self, groups_client):
+        resp = _create(groups_client, master_valve=9)  # valve_count mocked to 4
+        assert resp.status_code == 400
+
+    def test_master_cannot_be_member(self, groups_client):
+        resp = _create(groups_client, master=MASTER, master_valve=0,
+                       members=[{'zone_device_id': MASTER, 'zone_valve': 0}])
+        assert resp.status_code == 400
+
+    def test_duplicate_zone_membership_rejected(self, groups_client):
+        assert _create(groups_client, name='G1').status_code == 201
+        # Same zone valve in a second group -> 409.
+        resp = _create(groups_client, name='G2', master=ZONE_B, master_valve=0,
+                       members=[{'zone_device_id': ZONE_A, 'zone_valve': 0}])
+        assert resp.status_code == 409
+
+    def test_master_reuse_rejected(self, groups_client):
+        assert _create(groups_client, name='G1', master=MASTER, master_valve=3,
+                       members=[{'zone_device_id': ZONE_A, 'zone_valve': 0}]).status_code == 201
+        resp = _create(groups_client, name='G2', master=MASTER, master_valve=3,
+                       members=[{'zone_device_id': ZONE_B, 'zone_valve': 0}])
+        assert resp.status_code == 409
+
+    def test_update(self, groups_client):
+        group = _create(groups_client).get_json()
+        resp = groups_client.put(f"/api/valve-groups/{group['id']}", json={
+            'name': 'Renamed',
+            'members': [{'zone_device_id': ZONE_B, 'zone_valve': 2}]})
+        assert resp.status_code == 200
+        updated = resp.get_json()
+        assert updated['name'] == 'Renamed'
+        assert updated['members'] == [{'zone_device_id': ZONE_B, 'zone_valve': 2}]
+
+    def test_delete(self, groups_client):
+        group = _create(groups_client).get_json()
+        assert groups_client.delete(f"/api/valve-groups/{group['id']}").status_code == 200
+        assert groups_client.get(f"/api/valve-groups/{group['id']}").status_code == 404
+
+    def test_resync(self, groups_client):
+        group = _create(groups_client).get_json()
+        resp = groups_client.post(f"/api/valve-groups/{group['id']}/resync")
+        assert resp.status_code == 200
+        assert resp.get_json()['status'] == 'resynced'

--- a/api/tests/test_valve_groups_db.py
+++ b/api/tests/test_valve_groups_db.py
@@ -1,0 +1,104 @@
+"""Tests for the valve-group database layer."""
+import duckdb
+import pytest
+
+MASTER = 0x1111111111111111
+ZONE_A = 0x2222222222222222
+ZONE_B = 0x3333333333333333
+
+
+def _members(*pairs):
+    return [{'zone_device_id': dev, 'zone_valve': valve} for dev, valve in pairs]
+
+
+class TestValveGroupCrud:
+    def test_create_and_get(self, temp_db):
+        group = temp_db.create_valve_group(
+            'Front beds', MASTER, 3, _members((ZONE_A, 0), (ZONE_B, 1)))
+        assert group['name'] == 'Front beds'
+        assert group['master_device_id'] == str(MASTER)  # stringified
+        assert group['master_valve'] == 3
+        assert len(group['members']) == 2
+
+        fetched = temp_db.get_valve_group(group['id'])
+        assert fetched == group
+
+    def test_get_all(self, temp_db):
+        temp_db.create_valve_group('G1', MASTER, 0, _members((ZONE_A, 0)))
+        temp_db.create_valve_group('G2', ZONE_B, 0, _members((ZONE_A, 1)))
+        assert len(temp_db.get_all_valve_groups()) == 2
+
+    def test_get_group_for_zone_valve(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3, _members((ZONE_A, 0)))
+        found = temp_db.get_group_for_zone_valve(ZONE_A, 0)
+        assert found['id'] == group['id']
+        assert temp_db.get_group_for_zone_valve(ZONE_A, 1) is None
+
+    def test_update_members(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3, _members((ZONE_A, 0)))
+        temp_db.update_valve_group(group['id'], name='Renamed',
+                                   members=_members((ZONE_B, 2)))
+        updated = temp_db.get_valve_group(group['id'])
+        assert updated['name'] == 'Renamed'
+        assert updated['members'] == [{'zone_device_id': str(ZONE_B), 'zone_valve': 2}]
+        # Old member no longer mapped.
+        assert temp_db.get_group_for_zone_valve(ZONE_A, 0) is None
+
+    def test_delete(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3, _members((ZONE_A, 0)))
+        assert temp_db.delete_valve_group(group['id']) is True
+        assert temp_db.get_valve_group(group['id']) is None
+        assert temp_db.delete_valve_group(group['id']) is False
+
+
+class TestValveGroupUniqueness:
+    def test_zone_valve_in_one_group_only(self, temp_db):
+        temp_db.create_valve_group('G1', MASTER, 3, _members((ZONE_A, 0)))
+        with pytest.raises(duckdb.Error):
+            temp_db.create_valve_group('G2', ZONE_B, 0, _members((ZONE_A, 0)))
+
+    def test_master_valve_backs_one_group_only(self, temp_db):
+        temp_db.create_valve_group('G1', MASTER, 3, _members((ZONE_A, 0)))
+        with pytest.raises(duckdb.Error):
+            temp_db.create_valve_group('G2', MASTER, 3, _members((ZONE_B, 0)))
+
+
+class TestMasterSlots:
+    def test_replace_and_list(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3, _members((ZONE_A, 0)))
+        temp_db.replace_master_slots(group['id'], MASTER, [
+            {'master_index': 0, 'hour': 6, 'minute': 0, 'duration': 900, 'days': 127},
+            {'master_index': 1, 'hour': 18, 'minute': 0, 'duration': 600, 'days': 127},
+        ])
+        slots = temp_db.list_master_slots(MASTER)
+        assert len(slots) == 2
+        assert slots[0]['master_index'] == 0
+        assert slots[0]['group_id'] == group['id']
+
+        # Replace with a smaller set.
+        temp_db.replace_master_slots(group['id'], MASTER, [
+            {'master_index': 0, 'hour': 6, 'minute': 0, 'duration': 900, 'days': 127},
+        ])
+        assert len(temp_db.list_master_slots(MASTER)) == 1
+
+
+class TestDeleteNodeCleanup:
+    def test_delete_master_node_removes_group(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3, _members((ZONE_A, 0)))
+        temp_db.replace_master_slots(group['id'], MASTER, [
+            {'master_index': 0, 'hour': 6, 'minute': 0, 'duration': 900, 'days': 127}])
+        # Seed a nodes row so delete_node finds the node to delete.
+        temp_db.set_node_valve_count(MASTER, 4)
+
+        assert temp_db.delete_node(MASTER) is True
+        assert temp_db.get_valve_group(group['id']) is None
+        assert temp_db.list_master_slots(MASTER) == []
+
+    def test_delete_member_node_removes_membership(self, temp_db):
+        group = temp_db.create_valve_group('G', MASTER, 3,
+                                           _members((ZONE_A, 0), (ZONE_B, 1)))
+        temp_db.set_node_valve_count(ZONE_A, 2)
+        assert temp_db.delete_node(ZONE_A) is True
+        remaining = temp_db.get_valve_group(group['id'])
+        assert remaining is not None
+        assert remaining['members'] == [{'zone_device_id': str(ZONE_B), 'zone_valve': 1}]

--- a/api/tests/test_valve_groups_engine.py
+++ b/api/tests/test_valve_groups_engine.py
@@ -1,0 +1,142 @@
+"""Unit tests for the master-valve mirror engine (pure logic, no DB/IO)."""
+import pytest
+
+from valve_groups import (compute_master_windows, diff_master_slots,
+                          MasterSlotOverflow, USABLE_MASTER_SLOTS)
+
+ALL_DAYS = 0b1111111  # 127
+
+
+def _sched(hour, minute, duration, days=ALL_DAYS, valve=0, index=0):
+    return {'index': index, 'hour': hour, 'minute': minute,
+            'duration': duration, 'days': days, 'valve': valve}
+
+
+class TestComputeMasterWindows:
+    def test_empty(self):
+        assert compute_master_windows([], master_valve=3) == []
+
+    def test_single_window_mirrored(self):
+        # 06:00 for 15 min, every day -> one master window, same shape.
+        windows = compute_master_windows([_sched(6, 0, 900)], master_valve=3)
+        assert windows == [{'hour': 6, 'minute': 0, 'duration': 900,
+                            'days': ALL_DAYS, 'valve': 3}]
+
+    def test_overlapping_zones_merge_to_union(self):
+        # zone A 06:00-06:15, zone B 06:10-06:25 (overlap) -> one 06:00-06:25.
+        windows = compute_master_windows(
+            [_sched(6, 0, 900), _sched(6, 10, 900)], master_valve=0)
+        assert len(windows) == 1
+        assert windows[0]['hour'] == 6 and windows[0]['minute'] == 0
+        assert windows[0]['duration'] == 25 * 60
+
+    def test_abutting_zones_merge(self):
+        # Back-to-back 06:00-06:15 and 06:15-06:30 -> one continuous 06:00-06:30.
+        windows = compute_master_windows(
+            [_sched(6, 0, 900), _sched(6, 15, 900)], master_valve=0)
+        assert len(windows) == 1
+        assert windows[0]['duration'] == 30 * 60
+
+    def test_staggered_zones_stay_separate(self):
+        # Gap between zones -> master closed in the gap -> two windows.
+        windows = compute_master_windows(
+            [_sched(6, 0, 900), _sched(6, 20, 900)], master_valve=0)
+        assert len(windows) == 2
+        starts = sorted((w['hour'], w['minute']) for w in windows)
+        assert starts == [(6, 0), (6, 20)]
+
+    def test_same_window_across_days_regroups_to_one_slot(self):
+        # Same time on Mon/Wed/Fri (separate schedules) -> one window, combined days.
+        mon, wed, fri = 0b0000010, 0b0001000, 0b0100000
+        windows = compute_master_windows([
+            _sched(6, 0, 900, days=mon, index=0),
+            _sched(6, 0, 900, days=wed, index=1),
+            _sched(6, 0, 900, days=fri, index=2),
+        ], master_valve=0)
+        assert len(windows) == 1
+        assert windows[0]['days'] == (mon | wed | fri)
+
+    def test_distinct_times_distinct_slots(self):
+        windows = compute_master_windows(
+            [_sched(6, 0, 900), _sched(18, 0, 1800)], master_valve=0)
+        assert len(windows) == 2
+
+    def test_midnight_crossing_splits_into_next_day(self):
+        # Sunday 23:30 for 1h -> Sun 23:30-24:00 and Mon 00:00-00:30.
+        sun = 0b0000001
+        windows = compute_master_windows(
+            [_sched(23, 30, 3600, days=sun)], master_valve=0)
+        assert len(windows) == 2
+        by_start = {(w['hour'], w['minute']): w for w in windows}
+        assert by_start[(23, 30)]['duration'] == 30 * 60
+        assert by_start[(23, 30)]['days'] == sun
+        assert by_start[(0, 0)]['duration'] == 30 * 60
+        assert by_start[(0, 0)]['days'] == 0b0000010  # Monday
+
+    def test_overflow_raises(self):
+        # More distinct windows than usable slots -> overflow. Space each 5-min
+        # window 10 min apart (non-overlapping, valid hours) so each is its own
+        # master slot.
+        scheds = []
+        for i in range(USABLE_MASTER_SLOTS + 1):
+            total_min = i * 10
+            scheds.append(_sched(total_min // 60, total_min % 60, 300, index=i))
+        with pytest.raises(MasterSlotOverflow):
+            compute_master_windows(scheds, master_valve=0)
+
+    def test_long_merged_window_split_to_fit_uint16_duration(self):
+        # A continuous span longer than 65535s must be split into chunks that fit.
+        # Two back-to-back 18000s (5h) windows = 10h continuous = 36000s < 65535,
+        # so build a longer chain: 06:00 for 65000s + abutting next.
+        windows = compute_master_windows([
+            _sched(0, 0, 65000, index=0),
+            _sched(18, 3, 20000, index=1),  # starts at 65000-ish boundary region
+        ], master_valve=0)
+        for w in windows:
+            assert w['duration'] <= 65535
+
+
+class TestDiffMasterSlots:
+    def test_all_new(self):
+        desired = [{'hour': 6, 'minute': 0, 'duration': 900, 'days': ALL_DAYS, 'valve': 0}]
+        diff = diff_master_slots(desired, [], group_id=1)
+        assert len(diff['to_set']) == 1
+        assert diff['to_set'][0]['master_index'] == 0
+        assert diff['to_remove'] == []
+        assert len(diff['slots']) == 1
+
+    def test_unchanged_no_set(self):
+        desired = [{'hour': 6, 'minute': 0, 'duration': 900, 'days': ALL_DAYS, 'valve': 0}]
+        stored = [{'group_id': 1, 'master_index': 0, 'hour': 6, 'minute': 0,
+                   'duration': 900, 'days': ALL_DAYS}]
+        diff = diff_master_slots(desired, stored, group_id=1)
+        assert diff['to_set'] == []
+        assert diff['to_remove'] == []
+
+    def test_duration_change_resends_same_index(self):
+        # Window shrank (a contributing zone removed) -> SET same slot in place.
+        desired = [{'hour': 6, 'minute': 0, 'duration': 600, 'days': ALL_DAYS, 'valve': 0}]
+        stored = [{'group_id': 1, 'master_index': 0, 'hour': 6, 'minute': 0,
+                   'duration': 900, 'days': ALL_DAYS}]
+        diff = diff_master_slots(desired, stored, group_id=1)
+        assert len(diff['to_set']) == 1
+        assert diff['to_set'][0]['master_index'] == 0
+        assert diff['to_set'][0]['duration'] == 600
+        assert diff['to_remove'] == []
+
+    def test_removed_window(self):
+        desired = []
+        stored = [{'group_id': 1, 'master_index': 2, 'hour': 6, 'minute': 0,
+                   'duration': 900, 'days': ALL_DAYS}]
+        diff = diff_master_slots(desired, stored, group_id=1)
+        assert diff['to_remove'] == [2]
+        assert diff['slots'] == []
+
+    def test_other_groups_indices_avoided(self):
+        # Index 0 used by another group on the same device -> new window gets 1.
+        desired = [{'hour': 7, 'minute': 0, 'duration': 900, 'days': ALL_DAYS, 'valve': 0}]
+        stored = [{'group_id': 99, 'master_index': 0, 'hour': 6, 'minute': 0,
+                   'duration': 900, 'days': ALL_DAYS}]
+        diff = diff_master_slots(desired, stored, group_id=1)
+        assert diff['to_set'][0]['master_index'] == 1
+        assert diff['to_remove'] == []  # other group's slot untouched

--- a/api/valve_groups.py
+++ b/api/valve_groups.py
@@ -1,0 +1,189 @@
+"""Master-valve group orchestration — pure compilation logic.
+
+A valve group links N zone valves to one master valve (usually on a different
+node). The master is a *series* belt-and-suspenders shutoff: water reaches a zone
+only if both the zone valve and the master are open, so the master must be open
+when — and only when — one of its zone valves is actively watering. Because nodes
+sleep between a valve open and its auto-close, the master cannot be coordinated in
+real time; instead the API mirrors each zone's watering window onto the master
+node as its own schedule, so both nodes run autonomously from their RTCs.
+
+This module holds the *pure* compilation (no DB/queue I/O) so it is unit-testable.
+The only merging is of zone windows that genuinely overlap or abut in time —
+required because the master is a single valve and the PMU rejects overlapping
+schedules on the same valve. Non-overlapping (staggered) zones each get their own
+master window, so the master stays CLOSED in the gaps (exact per-zone mirror).
+"""
+from models import MAX_SCHEDULE_SLOTS
+
+SECONDS_PER_DAY = 86400
+MAX_SCHEDULE_DURATION = 65535  # PMU schedule duration field is uint16_t
+# Reserve the top slot for one-shot run-once, matching the zone-node convention.
+USABLE_MASTER_SLOTS = MAX_SCHEDULE_SLOTS - 1
+
+
+class MasterSlotOverflow(Exception):
+    """Raised when a group needs more master schedule slots than are available."""
+
+    def __init__(self, needed: int, available: int):
+        self.needed = needed
+        self.available = available
+        super().__init__(
+            f"master valve needs {needed} schedule slots but only {available} "
+            f"are available")
+
+
+def _day_intervals(schedules: list[dict]) -> dict:
+    """Return {day: [(start_sec, end_sec), ...]} from zone schedules (UTC).
+
+    Each schedule contributes an interval on each day in its bitmask (bit 0 =
+    Sunday). A window that crosses midnight is split into the tail on the
+    following day. A single zone duration is <= MAX_SCHEDULE_DURATION (< 1 day),
+    so at most one midnight crossing per schedule.
+    """
+    by_day: dict = {d: [] for d in range(7)}
+    for sched in schedules:
+        duration = sched['duration']
+        if duration <= 0:
+            continue
+        start = sched['hour'] * 3600 + sched['minute'] * 60
+        end = start + duration
+        for day in range(7):
+            if not (sched['days'] >> day) & 1:
+                continue
+            if end <= SECONDS_PER_DAY:
+                by_day[day].append((start, end))
+            else:
+                by_day[day].append((start, SECONDS_PER_DAY))
+                by_day[(day + 1) % 7].append((0, end - SECONDS_PER_DAY))
+    return by_day
+
+
+def _merge(intervals: list) -> list:
+    """Merge overlapping/abutting [start, end) intervals; return sorted list."""
+    if not intervals:
+        return []
+    ordered = sorted(intervals)
+    merged = [list(ordered[0])]
+    for start, end in ordered[1:]:
+        if start <= merged[-1][1]:  # overlaps or abuts the current run
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(s, e) for s, e in merged]
+
+
+def _split_long(start: int, end: int) -> list:
+    """Split [start, end) into consecutive chunks no longer than the PMU max
+    duration so each fits a uint16_t. Chunks abut, so the master stays
+    continuously open across the boundaries."""
+    chunks = []
+    cursor = start
+    while end - cursor > MAX_SCHEDULE_DURATION:
+        chunks.append((cursor, cursor + MAX_SCHEDULE_DURATION))
+        cursor += MAX_SCHEDULE_DURATION
+    chunks.append((cursor, end))
+    return chunks
+
+
+def compute_master_windows(member_schedules: list[dict], master_valve: int,
+                           usable_slots: int = USABLE_MASTER_SLOTS) -> list[dict]:
+    """Compile zone schedules into the master valve's desired schedule windows.
+
+    Returns a deterministic list of {hour, minute, duration, days, valve} dicts.
+    Raises MasterSlotOverflow if more than usable_slots distinct windows result.
+    """
+    by_day = _day_intervals(member_schedules)
+    # (start_sec, duration_sec) shape -> days bitmask it appears on
+    shape_days: dict = {}
+    for day, intervals in by_day.items():
+        for start, end in _merge(intervals):
+            for chunk_start, chunk_end in _split_long(start, end):
+                shape = (chunk_start, chunk_end - chunk_start)
+                shape_days[shape] = shape_days.get(shape, 0) | (1 << day)
+
+    if len(shape_days) > usable_slots:
+        raise MasterSlotOverflow(len(shape_days), usable_slots)
+
+    windows = []
+    for (start, duration), days in sorted(shape_days.items()):
+        windows.append({
+            'hour': start // 3600,
+            'minute': (start % 3600) // 60,
+            'duration': duration,
+            'days': days,
+            'valve': master_valve,
+        })
+    return windows
+
+
+def _window_key(window: dict) -> tuple:
+    return (window['hour'], window['minute'], window['days'])
+
+
+def diff_master_slots(desired: list[dict], stored_slots: list[dict],
+                      group_id: int,
+                      usable_slots: int = USABLE_MASTER_SLOTS) -> dict:
+    """Diff desired master windows against the slots the API currently owns.
+
+    Args:
+        desired: windows from compute_master_windows (for this group).
+        stored_slots: list_master_slots(master_device_id) — ALL slots on the
+            master device (the index space is shared across any groups it
+            masters), each carrying its group_id.
+        group_id: the group being recomputed.
+
+    Returns dict with:
+        'to_set':    [{master_index, hour, minute, duration, days, valve}] -> SET_SCHEDULE
+        'to_remove': [master_index, ...] -> REMOVE_SCHEDULE
+        'slots':     full new slot rows for this group (for replace_master_slots)
+
+    Matched windows (same hour/minute/days) keep their slot index and are only
+    re-sent when the duration changed (window shrank/grew). Removed indices are
+    freed for reuse. Raises MasterSlotOverflow if the device lacks free indices
+    (only possible when one device masters several groups).
+    """
+    this_group = [s for s in stored_slots if s['group_id'] == group_id]
+    used_by_others = {s['master_index'] for s in stored_slots
+                      if s['group_id'] != group_id}
+    stored_by_key = {_window_key(s): s for s in this_group}
+
+    to_set: list = []
+    new_slots: list = []
+    matched_keys: set = set()
+    reused_indices: set = set()
+    unmatched: list = []
+
+    for window in desired:
+        key = _window_key(window)
+        slot = stored_by_key.get(key)
+        if slot is not None:
+            index = slot['master_index']
+            matched_keys.add(key)
+            reused_indices.add(index)
+            new_slots.append({**window, 'master_index': index})
+            if slot['duration'] != window['duration']:
+                to_set.append({**window, 'master_index': index})
+        else:
+            unmatched.append(window)
+
+    to_remove = [s['master_index'] for s in this_group
+                 if _window_key(s) not in matched_keys]
+
+    occupied = used_by_others | reused_indices
+    free_indices = [i for i in range(usable_slots) if i not in occupied]
+    if len(free_indices) < len(unmatched):
+        raise MasterSlotOverflow(
+            len(used_by_others) + len(reused_indices) + len(unmatched),
+            usable_slots)
+
+    for window, index in zip(unmatched, free_indices):
+        new_slots.append({**window, 'master_index': index})
+        to_set.append({**window, 'master_index': index})
+
+    # Don't REMOVE an index we immediately reused (a SET overwrites it in place).
+    assigned = {s['master_index'] for s in new_slots}
+    to_remove = [i for i in to_remove if i not in assigned]
+
+    new_slots.sort(key=lambda s: s['master_index'])
+    return {'to_set': to_set, 'to_remove': to_remove, 'slots': new_slots}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -97,6 +97,7 @@ function App() {
 
   const isNodesActive = location.pathname === '/nodes' || location.pathname.startsWith('/nodes/');
   const isVisualizeActive = location.pathname === '/visualize';
+  const isValveGroupsActive = location.pathname === '/valve-groups';
   const isSettingsActive = location.pathname === '/settings';
 
   const contextValue: AppContextType = {
@@ -148,6 +149,14 @@ function App() {
                   }`}
                 >
                   Visualize
+                </Link>
+                <Link
+                  to="/valve-groups"
+                  className={`px-3 py-1.5 rounded text-sm font-medium transition-opacity ${
+                    isValveGroupsActive ? 'bg-white/15' : 'hover:bg-white/10 hover:opacity-80'
+                  }`}
+                >
+                  Valve Groups
                 </Link>
                 <Link
                   to="/settings"

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -7,6 +7,9 @@ import type {
   NodeStatistics,
   Zone,
   ZonesResponse,
+  ValveGroup,
+  ValveGroupMember,
+  ValveGroupsResponse,
   NodeEventsResponse,
   NodeCommandsResponse,
   NodeCommandStatus,
@@ -187,6 +190,51 @@ export async function updateZone(
 export async function deleteZone(zoneId: number): Promise<void> {
   await fetchApi<{ message: string }>(`/api/zones/${zoneId}`, {
     method: 'DELETE',
+  });
+}
+
+export async function getValveGroups(): Promise<ValveGroupsResponse> {
+  return fetchApi<ValveGroupsResponse>('/api/valve-groups');
+}
+
+export async function createValveGroup(group: {
+  name: string;
+  master_device_id: string;
+  master_valve: number;
+  members: ValveGroupMember[];
+}): Promise<ValveGroup> {
+  return fetchApi<ValveGroup>('/api/valve-groups', {
+    method: 'POST',
+    body: JSON.stringify(group),
+  });
+}
+
+export async function updateValveGroup(
+  groupId: number,
+  updates: Partial<{
+    name: string;
+    master_device_id: string;
+    master_valve: number;
+    members: ValveGroupMember[];
+  }>
+): Promise<ValveGroup> {
+  return fetchApi<ValveGroup>(`/api/valve-groups/${groupId}`, {
+    method: 'PUT',
+    body: JSON.stringify(updates),
+  });
+}
+
+export async function deleteValveGroup(groupId: number): Promise<void> {
+  await fetchApi<{ status: string }>(`/api/valve-groups/${groupId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function resyncValveGroup(
+  groupId: number
+): Promise<{ status: string; id: number; set: number; removed: number }> {
+  return fetchApi(`/api/valve-groups/${groupId}/resync`, {
+    method: 'POST',
   });
 }
 

--- a/dashboard/src/components/IrrigationControl.tsx
+++ b/dashboard/src/components/IrrigationControl.tsx
@@ -7,8 +7,9 @@ import {
   getIrrigationSchedules,
   addIrrigationSchedule,
   deleteIrrigationSchedule,
+  getValveGroups,
 } from '../api/client';
-import type { IrrigationSchedule } from '../types';
+import type { IrrigationSchedule, ValveGroup } from '../types';
 import { DAY_LABELS } from '../types';
 import { REFRESH_INTERVAL_MS } from '../config';
 import { SchedulesList } from './SchedulesList';
@@ -26,6 +27,10 @@ interface IrrigationControlProps {
   valveCount: number;
   onEventTriggered?: () => void;
 }
+
+// On-node schedule slots (must match PMU MAX_SCHEDULE_ENTRIES). The top slot is
+// reserved for one-shot "run now"; persistent schedules use 0..MAX_SCHEDULE_SLOTS-2.
+const MAX_SCHEDULE_SLOTS = 100;
 
 // Non-linear notches: fine-grained at short durations, coarser for long runs
 const DURATION_NOTCHES = [1, 5, 10, 15, 20, 30, 45, 60, 90, 120]; // minutes
@@ -66,6 +71,9 @@ function IrrigationControl({ deviceId, valveCount, onEventTriggered }: Irrigatio
     setValveStates((prev) => ({ ...prev, [valve]: next }));
   }, []);
 
+  // Valve groups this node participates in (read-only badges)
+  const [valveGroups, setValveGroups] = useState<ValveGroup[]>([]);
+
   // Schedule state
   const [schedules, setSchedules] = useState<IrrigationSchedule[]>([]);
   const [loadingSchedules, setLoadingSchedules] = useState(true);
@@ -97,6 +105,40 @@ function IrrigationControl({ deviceId, valveCount, onEventTriggered }: Irrigatio
     const interval = setInterval(fetchSchedules, REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [fetchSchedules]);
+
+  // Load valve groups once to annotate valves that participate in a group.
+  useEffect(() => {
+    let cancelled = false;
+    getValveGroups()
+      .then((response) => {
+        if (!cancelled) setValveGroups(response.groups);
+      })
+      .catch(() => {
+        // Badges are non-essential; ignore failures.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Returns a badge descriptor for a given valve on this node, or null if the
+  // valve isn't part of any group.
+  const valveGroupBadge = (
+    valve: number
+  ): { label: string; tone: 'master' | 'member' } | null => {
+    for (const group of valveGroups) {
+      if (group.master_device_id === deviceId && group.master_valve === valve) {
+        return { label: `Master · ${group.name}`, tone: 'master' };
+      }
+      const member = group.members.find(
+        (m) => m.zone_device_id === deviceId && m.zone_valve === valve
+      );
+      if (member) {
+        return { label: `In group: ${group.name}`, tone: 'member' };
+      }
+    }
+    return null;
+  };
 
   const handleRun = async (valve: number) => {
     setValveState(valve, { state: 'sending', action: 'run' });
@@ -147,15 +189,15 @@ function IrrigationControl({ deviceId, valveCount, onEventTriggered }: Irrigatio
       // Find next available index
       const usedIndices = new Set(schedules.map((s) => s.index));
       let nextIndex = -1;
-      for (let i = 0; i < 7; i++) {
-        // Reserve index 7 for run-once
+      // Reserve the top slot for run-once; persistent schedules use 0..MAX-2.
+      for (let i = 0; i < MAX_SCHEDULE_SLOTS - 1; i++) {
         if (!usedIndices.has(i)) {
           nextIndex = i;
           break;
         }
       }
       if (nextIndex === -1) {
-        setScheduleError('Maximum schedules reached (7)');
+        setScheduleError(`Maximum schedules reached (${MAX_SCHEDULE_SLOTS - 1})`);
         setSavingSchedule(false);
         return;
       }
@@ -209,10 +251,30 @@ function IrrigationControl({ deviceId, valveCount, onEventTriggered }: Irrigatio
     const isRunSending = valveState.state === 'sending' && valveState.action === 'run';
     const isStopSending = valveState.state === 'sending' && valveState.action === 'stop';
 
+    const groupBadge = valveGroupBadge(valve);
+
     return (
       <div key={valve} className="space-y-3">
         {/* Header */}
-        <h3 className="font-medium text-gray-900">Valve {valve + 1}</h3>
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="font-medium text-gray-900">Valve {valve + 1}</h3>
+          {groupBadge && (
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                groupBadge.tone === 'master'
+                  ? 'bg-amber-100 text-amber-800'
+                  : 'bg-blue-100 text-blue-800'
+              }`}
+              title={
+                groupBadge.tone === 'master'
+                  ? 'This valve is the master shutoff for a valve group.'
+                  : 'This valve is a zone member of a valve group.'
+              }
+            >
+              {groupBadge.label}
+            </span>
+          )}
+        </div>
 
         {/* Duration chips */}
         <div className="overflow-x-auto scrollbar-hide">

--- a/dashboard/src/components/ValveGroups.tsx
+++ b/dashboard/src/components/ValveGroups.tsx
@@ -1,0 +1,580 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Plus, Pencil, Trash2, RefreshCw, X, Layers, Info } from 'lucide-react';
+import type { Node, ValveGroup, ValveGroupMember } from '../types';
+import {
+  getValveGroups,
+  createValveGroup,
+  updateValveGroup,
+  deleteValveGroup,
+  resyncValveGroup,
+} from '../api/client';
+import { useAppContext } from '../App';
+
+// Friendly name for a node, falling back to its hex device id (device ids are
+// 64-bit strings — never coerce to number).
+function nodeDisplayName(node: Node): string {
+  return node.metadata?.name || `Node ${BigInt(node.device_id).toString(16).toUpperCase()}`;
+}
+
+// Display name for a device id that may or may not be a known node.
+function deviceDisplayName(deviceId: string, nodeMap: Map<string, Node>): string {
+  const node = nodeMap.get(deviceId);
+  if (node) return nodeDisplayName(node);
+  return `Node ${BigInt(deviceId).toString(16).toUpperCase()}`;
+}
+
+// Nodes that report a valve_count > 0 can host master/zone valves.
+function hasValves(node: Node): boolean {
+  return node.valve_count != null && node.valve_count > 0;
+}
+
+type ResyncStatus = { groupId: number; set: number; removed: number };
+
+interface ValveGroupFormState {
+  name: string;
+  masterDeviceId: string;
+  masterValve: number;
+  members: ValveGroupMember[];
+}
+
+const EMPTY_FORM: ValveGroupFormState = {
+  name: '',
+  masterDeviceId: '',
+  masterValve: 0,
+  members: [],
+};
+
+function memberKey(member: ValveGroupMember): string {
+  return `${member.zone_device_id}:${member.zone_valve}`;
+}
+
+function ValveGroups() {
+  const { nodes } = useAppContext();
+
+  const [groups, setGroups] = useState<ValveGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Modal state: null = closed, otherwise the group being edited (or a fresh form for create).
+  const [editing, setEditing] = useState<ValveGroup | 'new' | null>(null);
+
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [resyncingId, setResyncingId] = useState<number | null>(null);
+  const [resyncStatus, setResyncStatus] = useState<ResyncStatus | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const valveNodes = useMemo(() => nodes.filter(hasValves), [nodes]);
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, Node>();
+    nodes.forEach((n) => map.set(n.device_id, n));
+    return map;
+  }, [nodes]);
+
+  const fetchGroups = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await getValveGroups();
+      setGroups(response.groups);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load valve groups');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGroups();
+  }, [fetchGroups]);
+
+  // Auto-clear the transient resync status after a few seconds.
+  useEffect(() => {
+    if (!resyncStatus) return;
+    const timer = setTimeout(() => setResyncStatus(null), 5000);
+    return () => clearTimeout(timer);
+  }, [resyncStatus]);
+
+  const handleDelete = async (group: ValveGroup) => {
+    if (!window.confirm(`Delete valve group "${group.name}"? This removes the master valve link.`)) {
+      return;
+    }
+    setDeletingId(group.id);
+    setActionError(null);
+    try {
+      await deleteValveGroup(group.id);
+      await fetchGroups();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete valve group');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleResync = async (group: ValveGroup) => {
+    setResyncingId(group.id);
+    setActionError(null);
+    setResyncStatus(null);
+    try {
+      const result = await resyncValveGroup(group.id);
+      setResyncStatus({ groupId: group.id, set: result.set, removed: result.removed });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to re-sync valve group');
+    } finally {
+      setResyncingId(null);
+    }
+  };
+
+  const handleSaved = async () => {
+    setEditing(null);
+    await fetchGroups();
+  };
+
+  if (loading) {
+    return (
+      <div className="max-w-3xl">
+        <h2 className="text-xl font-semibold text-gray-900 mb-6">Valve Groups</h2>
+        <div className="space-y-3">
+          {[0, 1].map((i) => (
+            <div key={i} className="card animate-pulse">
+              <div className="h-5 w-40 bg-gray-200 rounded mb-3" />
+              <div className="h-4 w-64 bg-gray-200 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-xl font-semibold text-gray-900">Valve Groups</h2>
+        <button
+          onClick={() => {
+            setActionError(null);
+            setEditing('new');
+          }}
+          className="btn btn-primary flex items-center gap-2"
+        >
+          <Plus className="w-4 h-4" />
+          New Group
+        </button>
+      </div>
+
+      <p className="text-sm text-gray-500 mb-6">
+        A valve group pairs one <strong>master valve</strong> with one or more zone valves. The
+        master opens automatically whenever any of its zone valves runs, acting as a series shutoff.
+        The hub mirrors each zone&apos;s schedule onto the master node for you.
+      </p>
+
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm mb-4">
+          {error}
+        </div>
+      )}
+
+      {actionError && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm mb-4 flex items-start justify-between gap-3">
+          <span>{actionError}</span>
+          <button
+            onClick={() => setActionError(null)}
+            className="text-red-400 hover:text-red-600"
+            aria-label="Dismiss error"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {groups.length === 0 ? (
+        <div className="card text-center py-10">
+          <Layers className="w-10 h-10 text-gray-300 mx-auto mb-3" />
+          <p className="text-gray-600 font-medium">No valve groups yet</p>
+          <p className="text-sm text-gray-500 mt-1">
+            Create a group to link a master shutoff valve to its zone valves.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {groups.map((group) => (
+            <div key={group.id} className="card">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="text-lg font-medium text-gray-900 truncate">{group.name}</h3>
+                  <p className="text-sm text-gray-600 mt-0.5">
+                    Master:{' '}
+                    <span className="font-medium">
+                      {deviceDisplayName(group.master_device_id, nodeMap)}
+                    </span>{' '}
+                    · Valve {group.master_valve + 1}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={() => handleResync(group)}
+                    disabled={resyncingId === group.id}
+                    className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50"
+                    title="Re-sync master schedules to nodes"
+                  >
+                    <RefreshCw
+                      className={`w-4 h-4 ${resyncingId === group.id ? 'animate-spin' : ''}`}
+                    />
+                  </button>
+                  <button
+                    onClick={() => {
+                      setActionError(null);
+                      setEditing(group);
+                    }}
+                    className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                    title="Edit group"
+                  >
+                    <Pencil className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(group)}
+                    disabled={deletingId === group.id}
+                    className="p-2 rounded-md text-red-500 hover:bg-red-50 hover:text-red-700 disabled:opacity-50"
+                    title="Delete group"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+
+              {/* Member chips */}
+              <div className="mt-3">
+                <p className="text-xs font-medium text-gray-500 mb-1.5">
+                  {group.members.length} zone {group.members.length === 1 ? 'valve' : 'valves'}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {group.members.map((member) => (
+                    <span
+                      key={memberKey(member)}
+                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-gray-100 text-gray-700 text-xs"
+                    >
+                      {deviceDisplayName(member.zone_device_id, nodeMap)} · V{member.zone_valve + 1}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Transient resync status */}
+              {resyncStatus && resyncStatus.groupId === group.id && (
+                <div className="mt-3 p-2.5 bg-green-50 border border-green-200 rounded-md text-green-700 text-sm flex items-center gap-2">
+                  <RefreshCw className="w-4 h-4 shrink-0" />
+                  <span>
+                    Re-synced: {resyncStatus.set} master schedule
+                    {resyncStatus.set === 1 ? '' : 's'} set, {resyncStatus.removed} removed.
+                  </span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-6 flex items-start gap-2 text-xs text-gray-500">
+        <Info className="w-4 h-4 shrink-0 mt-0.5" />
+        <p>
+          <strong>Re-sync</strong> pushes the master valve&apos;s mirrored schedules to its node
+          again. Use it if a node was offline and missed an update.
+        </p>
+      </div>
+
+      {editing && (
+        <ValveGroupModal
+          group={editing === 'new' ? null : editing}
+          valveNodes={valveNodes}
+          onClose={() => setEditing(null)}
+          onSaved={handleSaved}
+        />
+      )}
+    </div>
+  );
+}
+
+interface ValveGroupModalProps {
+  group: ValveGroup | null; // null = create
+  valveNodes: Node[];
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function ValveGroupModal({ group, valveNodes, onClose, onSaved }: ValveGroupModalProps) {
+  const isEdit = group !== null;
+
+  const [form, setForm] = useState<ValveGroupFormState>(() =>
+    group
+      ? {
+          name: group.name,
+          masterDeviceId: group.master_device_id,
+          masterValve: group.master_valve,
+          members: group.members.map((m) => ({ ...m })),
+        }
+      : EMPTY_FORM
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Member-picker working state
+  const [memberDeviceId, setMemberDeviceId] = useState<string>('');
+  const [memberValve, setMemberValve] = useState<number>(0);
+
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, Node>();
+    valveNodes.forEach((n) => map.set(n.device_id, n));
+    return map;
+  }, [valveNodes]);
+
+  const masterNode = form.masterDeviceId ? nodeMap.get(form.masterDeviceId) : undefined;
+  const masterValveCount = masterNode?.valve_count ?? 0;
+
+  const memberNode = memberDeviceId ? nodeMap.get(memberDeviceId) : undefined;
+  const memberValveCount = memberNode?.valve_count ?? 0;
+
+  // The master valve cannot also be a member. Build the set of valves already
+  // claimed (as members) so we don't offer duplicates in the picker.
+  const claimedMemberKeys = useMemo(
+    () => new Set(form.members.map(memberKey)),
+    [form.members]
+  );
+
+  const addMember = () => {
+    if (!memberDeviceId) return;
+    const candidate: ValveGroupMember = {
+      zone_device_id: memberDeviceId,
+      zone_valve: memberValve,
+    };
+    // Prevent selecting the master valve as a member.
+    if (
+      candidate.zone_device_id === form.masterDeviceId &&
+      candidate.zone_valve === form.masterValve
+    ) {
+      setError('The master valve cannot also be a zone member.');
+      return;
+    }
+    if (claimedMemberKeys.has(memberKey(candidate))) {
+      setError('That valve is already a member of this group.');
+      return;
+    }
+    setError(null);
+    setForm((prev) => ({ ...prev, members: [...prev.members, candidate] }));
+  };
+
+  const removeMember = (member: ValveGroupMember) => {
+    setForm((prev) => ({
+      ...prev,
+      members: prev.members.filter((m) => memberKey(m) !== memberKey(member)),
+    }));
+  };
+
+  const handleSave = async () => {
+    const name = form.name.trim();
+    if (!name) {
+      setError('Name is required.');
+      return;
+    }
+    if (!form.masterDeviceId) {
+      setError('Select a master node.');
+      return;
+    }
+    if (form.members.length === 0) {
+      setError('Add at least one zone valve.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      if (isEdit && group) {
+        await updateValveGroup(group.id, {
+          name,
+          master_device_id: form.masterDeviceId,
+          master_valve: form.masterValve,
+          members: form.members,
+        });
+      } else {
+        await createValveGroup({
+          name,
+          master_device_id: form.masterDeviceId,
+          master_valve: form.masterValve,
+          members: form.members,
+        });
+      }
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save valve group');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // When the master node changes, clamp the master valve to a valid index.
+  const handleMasterNodeChange = (deviceId: string) => {
+    setForm((prev) => ({ ...prev, masterDeviceId: deviceId, masterValve: 0 }));
+  };
+
+  // Valve options for a node with the given valve_count.
+  const valveOptions = (count: number): number[] =>
+    Array.from({ length: count }, (_, i) => i);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative z-50 bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-lg font-medium text-gray-900">
+            {isEdit ? 'Edit Valve Group' : 'Create Valve Group'}
+          </h3>
+        </div>
+
+        <div className="px-6 py-4 space-y-5">
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          {valveNodes.length === 0 && (
+            <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-md text-yellow-800 text-sm">
+              No nodes report any valves. Connect an irrigation node before creating a group.
+            </div>
+          )}
+
+          {/* Name */}
+          <div>
+            <label htmlFor="group-name" className="block text-sm font-medium text-gray-700 mb-1">
+              Name *
+            </label>
+            <input
+              id="group-name"
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              placeholder="e.g., North field master"
+              className="input w-full"
+              autoFocus
+            />
+          </div>
+
+          {/* Master valve */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Master valve *</label>
+            <div className="flex gap-2">
+              <select
+                value={form.masterDeviceId}
+                onChange={(e) => handleMasterNodeChange(e.target.value)}
+                className="input flex-1"
+              >
+                <option value="">Select node…</option>
+                {valveNodes.map((node) => (
+                  <option key={node.device_id} value={node.device_id}>
+                    {nodeDisplayName(node)}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={form.masterValve}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, masterValve: parseInt(e.target.value, 10) }))
+                }
+                disabled={!masterNode}
+                className="input w-32 disabled:opacity-50"
+              >
+                {valveOptions(masterValveCount).map((v) => (
+                  <option key={v} value={v}>
+                    Valve {v + 1}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              Opens automatically whenever any zone valve below runs.
+            </p>
+          </div>
+
+          {/* Members */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Zone valves *</label>
+
+            {form.members.length > 0 ? (
+              <div className="flex flex-wrap gap-2 mb-3">
+                {form.members.map((member) => (
+                  <span
+                    key={memberKey(member)}
+                    className="inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full bg-gray-100 text-gray-700 text-xs"
+                  >
+                    {deviceDisplayName(member.zone_device_id, nodeMap)} · V
+                    {member.zone_valve + 1}
+                    <button
+                      type="button"
+                      onClick={() => removeMember(member)}
+                      className="text-gray-400 hover:text-gray-700"
+                      aria-label="Remove zone valve"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500 mb-3">No zone valves added yet.</p>
+            )}
+
+            <div className="flex gap-2">
+              <select
+                value={memberDeviceId}
+                onChange={(e) => {
+                  setMemberDeviceId(e.target.value);
+                  setMemberValve(0);
+                }}
+                className="input flex-1"
+              >
+                <option value="">Select node…</option>
+                {valveNodes.map((node) => (
+                  <option key={node.device_id} value={node.device_id}>
+                    {nodeDisplayName(node)}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={memberValve}
+                onChange={(e) => setMemberValve(parseInt(e.target.value, 10))}
+                disabled={!memberNode}
+                className="input w-28 disabled:opacity-50"
+              >
+                {valveOptions(memberValveCount).map((v) => (
+                  <option key={v} value={v}>
+                    Valve {v + 1}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={addMember}
+                disabled={!memberDeviceId}
+                className="btn btn-secondary disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">
+          <button onClick={onClose} disabled={saving} className="btn btn-secondary">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || valveNodes.length === 0}
+            className="btn btn-primary"
+          >
+            {saving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Group'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ValveGroups;

--- a/dashboard/src/routes.tsx
+++ b/dashboard/src/routes.tsx
@@ -3,6 +3,7 @@ import App from './App';
 import NodeList from './components/NodeList';
 import NodeDetailPage from './components/NodeDetailPage';
 import VisualizePage from './components/VisualizePage';
+import ValveGroups from './components/ValveGroups';
 import Settings from './components/Settings';
 
 export const router = createBrowserRouter([
@@ -25,6 +26,10 @@ export const router = createBrowserRouter([
       {
         path: 'visualize',
         element: <VisualizePage />,
+      },
+      {
+        path: 'valve-groups',
+        element: <ValveGroups />,
       },
       {
         path: 'settings',

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -10,6 +10,26 @@ export interface ZonesResponse {
   zones: Zone[];
 }
 
+export interface ValveGroupMember {
+  zone_device_id: string;  // String to preserve 64-bit precision
+  zone_valve: number;
+}
+
+export interface ValveGroup {
+  id: number;
+  name: string;
+  master_device_id: string;  // String to preserve 64-bit precision
+  master_valve: number;
+  members: ValveGroupMember[];
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ValveGroupsResponse {
+  count: number;
+  groups: ValveGroup[];
+}
+
 export interface NodeMetadata {
   device_id: string;  // String to preserve 64-bit precision
   name: string | null;

--- a/plans/valve_groups.md
+++ b/plans/valve_groups.md
@@ -1,0 +1,45 @@
+# Valve Groups (Master Valve)
+
+Status: implemented on branch `feature/valve-groups-master-valve`. Full design:
+`~/.claude/plans/virtual-sniffing-hanrahan.md`.
+
+## What it does
+A **valve group** links N zone valves to one **master valve** (usually on a different node). The
+master is a *series* belt-and-suspenders shutoff: water reaches a zone only if both the zone valve
+and the master are open. So the master must err **CLOSED** and open only while a specific zone is
+actively watering (exact per-zone mirror, closed in the gaps between staggered zones).
+
+## How (API-orchestrated, autonomous nodes)
+Nodes sleep between a valve open and its auto-close, so the master can't be coordinated in real time.
+Instead the API mirrors each zone watering window onto the **master node as its own schedule**; both
+nodes run autonomously from hub-synced RTCs. Only genuinely overlapping zone windows are merged (the
+PMU rejects overlapping schedules on one valve). Manual run/stop fan out to the master too.
+
+## Implemented
+- **Firmware (PMU):** `MAX_SCHEDULE_ENTRIES` 8 → 100 (`pmu-stm32/Core/Inc/pmu_protocol.h`); FRAM
+  `FORMAT_VERSION` 2 → 3 (`persistent_storage.h`) so the auto-derived layout reformats cleanly on
+  upgrade. **User must build/flash the PMU.**
+- **API index range:** schedule index widened from 0-7 to 0-99 (`models.py`, `app.py`); dashboard
+  slot loop too (`IrrigationControl.tsx`).
+- **DB (`api/database.py`):** tables `valve_groups`, `valve_group_members`,
+  `valve_group_master_slots`; CRUD + `get_group_for_zone_valve` + `list/replace_master_slots`;
+  `delete_node` cleanup.
+- **Mirror engine (`api/valve_groups.py`, pure):** `compute_master_windows` (per-day overlap merge,
+  midnight split, long-window split to fit uint16 duration, distinct-shape day regroup, slot-cap →
+  `MasterSlotOverflow`) and `diff_master_slots` (recompute + minimal SET/REMOVE diff, in-place
+  shrink/grow, index reuse).
+- **Endpoints (`api/app.py`):** `GET/POST /api/valve-groups`, `GET/PUT/DELETE
+  /api/valve-groups/<id>`, `POST /api/valve-groups/<id>/resync`; `add_schedule`/`remove_schedule`/
+  `run_valve`/`stop_valve` are group-aware (atomic 409 on master slot overflow). Master commands get
+  their own `node_commands` audit rows (auto-confirmed by existing event reconcilers).
+- **Dashboard:** `components/ValveGroups.tsx` (list/create/edit/delete/resync), nav route, and
+  read-only group badges in `IrrigationControl.tsx`.
+
+## Tests
+`api/tests/test_valve_groups_engine.py`, `_db.py`, `_api.py` — 34 passing (engine algorithm, DB
+layer + uniqueness + cleanup, endpoint wiring). Dashboard `npm run build` + `tsc --noEmit` clean.
+
+## Known limitations / follow-ups
+- **TTL expiry** (30 min) can leave the master out of sync → that zone waters with the master closed.
+  Mitigated by the manual `/resync`. A periodic reconciler is a recommended v1.1.
+- v1 enforces one group per master valve and one group per zone valve.

--- a/pmu-stm32/Core/Inc/persistent_storage.h
+++ b/pmu-stm32/Core/Inc/persistent_storage.h
@@ -124,7 +124,7 @@ private:
     static_assert(TOTAL_USED <= FRAM::CAPACITY, "Persistent storage layout exceeds FRAM capacity");
 
     static constexpr uint32_t MAGIC = 0x4652414D;  // "FRAM" in ASCII
-    static constexpr uint32_t FORMAT_VERSION = 2;  // Bumped: dynamic schedule layout
+    static constexpr uint32_t FORMAT_VERSION = 3;  // Bumped: MAX_SCHEDULE_ENTRIES 8->100 shifts layout
 
     uint16_t scheduleEntryOffset(uint8_t index) const
     {

--- a/pmu-stm32/Core/Inc/pmu_protocol.h
+++ b/pmu-stm32/Core/Inc/pmu_protocol.h
@@ -90,7 +90,7 @@ inline bool operator!(DayOfWeek a)
 // Protocol constants
 constexpr uint8_t START_BYTE = 0xAA;
 constexpr uint8_t END_BYTE = 0x55;
-constexpr uint8_t MAX_SCHEDULE_ENTRIES = 8;
+constexpr uint8_t MAX_SCHEDULE_ENTRIES = 100;
 constexpr uint8_t MAX_MESSAGE_SIZE = 48;  // Increased to accommodate state blob (was 32)
 constexpr uint8_t SCHEDULE_ENTRY_SIZE = 7;
 constexpr uint8_t NODE_STATE_SIZE = 32;      // Opaque state blob stored in PMU RAM

--- a/src/hal/pmu_protocol.h
+++ b/src/hal/pmu_protocol.h
@@ -227,9 +227,9 @@ using UartSendCallback = std::function<void(const uint8_t *data, uint8_t length)
 // valve_reset: one-shot flag set on the first wake after a PMU power-on (PORRSTF) or
 //   NRST-button reset (PINRSTF). When true, valves should be force-closed to a known
 //   state even if the state blob is otherwise valid.
-using WakeNotificationCallback = std::function<void(WakeReason reason, const ScheduleEntry *entry,
-                                                    bool state_valid, const uint8_t *state,
-                                                    bool valve_reset)>;
+using WakeNotificationCallback =
+    std::function<void(WakeReason reason, const ScheduleEntry *entry, bool state_valid,
+                       const uint8_t *state, bool valve_reset)>;
 using ScheduleCompleteCallback = std::function<void()>;
 using CommandResultCallback = std::function<void(bool success, ErrorCode error)>;
 using WakeIntervalCallback = std::function<void(uint32_t seconds)>;

--- a/src/modes/greenhouse_mode.cpp
+++ b/src/modes/greenhouse_mode.cpp
@@ -51,14 +51,15 @@ void GreenhouseMode::onStart()
         pmu_logger.info("PMU client initialized successfully");
 
         // Register wake notification callback (plumbing for future scheduled curtain operations)
-        pmu_client_->getProtocol().onWakeNotification(
-            [](PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool, const uint8_t *, bool) {
-                if (reason == PMU::WakeReason::Scheduled && entry) {
-                    pmu_logger.info("Scheduled wake: hour=%d min=%d duration=%ds", entry->hour,
-                                    entry->minute, entry->duration);
-                    // Future: trigger curtain open/close based on schedule
-                }
-            });
+        pmu_client_->getProtocol().onWakeNotification([](PMU::WakeReason reason,
+                                                         const PMU::ScheduleEntry *entry, bool,
+                                                         const uint8_t *, bool) {
+            if (reason == PMU::WakeReason::Scheduled && entry) {
+                pmu_logger.info("Scheduled wake: hour=%d min=%d duration=%ds", entry->hour,
+                                entry->minute, entry->duration);
+                // Future: trigger curtain open/close based on schedule
+            }
+        });
 
         // Register schedule complete callback (plumbing for future)
         pmu_client_->getProtocol().onScheduleComplete(

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -198,10 +198,9 @@ void IrrigationMode::onStateChange(IrrigationState state)
         case IrrigationState::AWAITING_REGISTRATION:
             // Send re-registration request (reset to unregistered so hub assigns a fresh address)
             messenger_.setNodeAddress(ADDRESS_UNREGISTERED);
-            messenger_.sendRegistrationRequest(ADDRESS_HUB, device_id_, NODE_TYPE_HYBRID,
-                                               CAP_VALVE_CONTROL | CAP_SOIL_MOISTURE,
-                                               BRAMBLE_FIRMWARE_VERSION, "Irrigation Node",
-                                               ValveController::NUM_VALVES);
+            messenger_.sendRegistrationRequest(
+                ADDRESS_HUB, device_id_, NODE_TYPE_HYBRID, CAP_VALVE_CONTROL | CAP_SOIL_MOISTURE,
+                BRAMBLE_FIRMWARE_VERSION, "Irrigation Node", ValveController::NUM_VALVES);
             // Set callback to advance SM when response arrives
             // Address is persisted via PMU state blob at sleep time (packState),
             // not flash — flash writes disrupt XIP cache on RP2350 and crash here.


### PR DESCRIPTION
## Summary
Adds **valve groups / master valve**: a master valve (usually on a different node) that opens only while an associated zone valve is actively watering — a series belt-and-suspenders shutoff that errs **closed**.

Because nodes sleep between a valve open and its auto-close, the master can't be coordinated in real time. Instead the API mirrors each zone's watering window onto the master node as its own schedule; both nodes run autonomously. Only genuinely overlapping zone windows merge (the PMU rejects overlapping schedules on one valve). Manual run/stop fan out to the master too.

## Changes
- **feat(pmu):** `MAX_SCHEDULE_ENTRIES` 8→100 (FRAM offsets auto-derive, `static_assert` guards), `FORMAT_VERSION` 2→3 for a clean reformat on upgrade. **Requires a PMU build + flash.**
- **feat(api):** pure mirror engine (`valve_groups.py`), group tables + methods + `delete_node` cleanup, group CRUD + `/resync` endpoints, group-aware `add_schedule`/`remove_schedule`/`run_valve`/`stop_valve` (atomic 409 on master slot overflow), widened schedule index range.
- **feat(dashboard):** valve group management page + nav + read-only group badges.
- **test(api):** 34 tests (engine, db, endpoints).

## Verification
- API: 34 valve-group tests pass; full suite green except one pre-existing unrelated failure (`test_device_id_in_to_dict`).
- Dashboard: `npm run build` + `tsc --noEmit` clean.

## Follow-ups
- Periodic reconciler so master schedules survive the 30-min command TTL (mitigated for now by `/resync`).
- AC valve controller (separate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)