### PR TITLE
feat(pmu): increase default wake interval to 5 minutes

### DIFF
--- a/pmu-stm32/Core/Src/persistent_storage.cpp
+++ b/pmu-stm32/Core/Src/persistent_storage.cpp
@@ -72,8 +72,8 @@ bool PersistentStorage::formatStorage()
         return false;
     }
 
-    // Default wake interval: 60 seconds (matches Protocol constructor default)
-    uint32_t defaultInterval = 60;
+    // Default wake interval: 300 seconds / 5 minutes (matches Protocol constructor default)
+    uint32_t defaultInterval = 300;
     if (!fram_.write(OFFSET_WAKE_INTERVAL, reinterpret_cast<uint8_t *>(&defaultInterval),
                      sizeof(defaultInterval))) {
         return false;

--- a/pmu-stm32/Core/Src/pmu_protocol.cpp
+++ b/pmu-stm32/Core/Src/pmu_protocol.cpp
@@ -515,7 +515,7 @@ uint8_t MessageBuilder::calculateChecksum() const
 
 Protocol::Protocol(UartSendCallback uartSend, SetWakeCallback setWake, KeepAwakeCallback keepAwake,
                    ReadyForSleepCallback readyForSleep, GetTickCallback getTick)
-    : wakeInterval_(60), nextSeqNum_(SEQ_STM32_MIN), currentSeqNum_(0), uartSend_(uartSend),
+    : wakeInterval_(300), nextSeqNum_(SEQ_STM32_MIN), currentSeqNum_(0), uartSend_(uartSend),
       setWake_(setWake), keepAwake_(keepAwake), readyForSleep_(readyForSleep), getTick_(getTick),
       seenIndex_(0), nodeStateValid_(false), valveResetPending_(false), clearToSendReceived_(false),
       pendingMessageReady_(false), pendingSeqNum_(0), pendingCommand_(static_cast<Command>(0)),


### PR DESCRIPTION
Changes the default sensor recording cadence from 60s to 300s (5 minutes) in the STM32 PMU firmware.

- `Protocol` constructor in-RAM default: `wakeInterval_(300)`
- Value written to FRAM on first init/wipe: `defaultInterval = 300`

Since the sensor records on each periodic PMU wake, the wake interval is the recording period.

**Note:** this only affects the *default*. Already-deployed PMUs keep their persisted 60s interval until sent a `SET_WAKE_INTERVAL` command from the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)