### PR TITLE
feat(irrigation): AC SSR valve controller variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build/
 Build/
 BUILD/
-build_v*/
+build_*/
 
 # Node / dashboard
 node_modules/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,8 @@ else()
     # Hardware variant selection (ALL builds every variant in parallel)
     set(HARDWARE_VARIANT "IRRIGATION" CACHE STRING "Hardware variant type")
     set_property(CACHE HARDWARE_VARIANT PROPERTY STRINGS
-        ALL GENERIC HUB CONTROLLER IRRIGATION SENSOR GREENHOUSE)
+        ALL GENERIC HUB CONTROLLER IRRIGATION IRRIGATION_AC SENSOR GREENHOUSE
+        VALVETEST VALVETEST_AC)
 
     # Radio chip selection (determines which driver is compiled)
     set(RADIO_CHIP "SX1262" CACHE STRING "Radio chip: SX1276 or SX1262")
@@ -236,6 +237,30 @@ else()
         message(STATUS "Building IRRIGATION variant")
     endif()
 
+    # AC valve node: mains-powered, always-awake, SSR-driven valves. Reuses the
+    # irrigation mode + valve controller; HARDWARE_IRRIGATION_AC selects the AC
+    # driver/pins and the never-sleep behavior.
+    if(HARDWARE_VARIANT STREQUAL "ALL" OR HARDWARE_VARIANT STREQUAL "IRRIGATION_AC")
+        add_executable(bramble_irrigation_ac${BOARD_SUFFIX}${RADIO_SUFFIX}
+            main.cpp
+            src/modes/irrigation_mode.cpp
+            src/hal/valve_controller.cpp
+            src/hal/hbridge.cpp
+            src/hal/valve_indexer.cpp
+            ${COMMON_SOURCES}
+        )
+        # Define HARDWARE_IRRIGATION too so the shared irrigation mode selection
+        # (main.cpp, variant info) works unchanged; HARDWARE_IRRIGATION_AC adds
+        # the AC driver/pins and never-sleep behavior on top.
+        target_compile_definitions(bramble_irrigation_ac${BOARD_SUFFIX}${RADIO_SUFFIX} PRIVATE
+            HARDWARE_IRRIGATION=1
+            HARDWARE_IRRIGATION_AC=1
+            DEFAULT_IS_HUB=0
+        )
+        list(APPEND BUILD_TARGETS bramble_irrigation_ac${BOARD_SUFFIX}${RADIO_SUFFIX})
+        message(STATUS "Building IRRIGATION_AC variant")
+    endif()
+
     # Standalone valve sweep test (bench bring-up, no LoRa/PMU)
     if(HARDWARE_VARIANT STREQUAL "VALVETEST")
         add_executable(bramble_valvetest${BOARD_SUFFIX}${RADIO_SUFFIX}
@@ -251,6 +276,26 @@ else()
         )
         list(APPEND BUILD_TARGETS bramble_valvetest${BOARD_SUFFIX}${RADIO_SUFFIX})
         message(STATUS "Building VALVETEST variant")
+    endif()
+
+    # Standalone AC valve sweep test (bench bring-up, no LoRa/PMU). Same sweep as
+    # VALVETEST but HARDWARE_IRRIGATION_AC selects the SSR-gate path (one GPIO per
+    # valve, no H-bridge/indexer).
+    if(HARDWARE_VARIANT STREQUAL "VALVETEST_AC")
+        add_executable(bramble_valvetest_ac${BOARD_SUFFIX}${RADIO_SUFFIX}
+            valve_test.cpp
+            src/hal/valve_controller.cpp
+            src/hal/hbridge.cpp
+            src/hal/valve_indexer.cpp
+            ${COMMON_SOURCES}
+        )
+        target_compile_definitions(bramble_valvetest_ac${BOARD_SUFFIX}${RADIO_SUFFIX} PRIVATE
+            HARDWARE_IRRIGATION=1
+            HARDWARE_IRRIGATION_AC=1
+            DEFAULT_IS_HUB=0
+        )
+        list(APPEND BUILD_TARGETS bramble_valvetest_ac${BOARD_SUFFIX}${RADIO_SUFFIX})
+        message(STATUS "Building VALVETEST_AC variant")
     endif()
 
     if(HARDWARE_VARIANT STREQUAL "ALL" OR HARDWARE_VARIANT STREQUAL "CONTROLLER")

--- a/main.cpp
+++ b/main.cpp
@@ -201,6 +201,8 @@ int main()
 
 #ifdef HARDWARE_CONTROLLER
     log.info("Hardware variant: CONTROLLER");
+#elif HARDWARE_IRRIGATION_AC
+    log.info("Hardware variant: IRRIGATION_AC (AC SSR valves)");
 #elif HARDWARE_IRRIGATION
     log.info("Hardware variant: IRRIGATION");
 #elif HARDWARE_SENSOR

--- a/plans/ac_valve_controller.md
+++ b/plans/ac_valve_controller.md
@@ -1,0 +1,50 @@
+# AC Valve Controller (mains, always-awake)
+
+Status: implemented on branch `feature/ac-valve-controller` (builds clean: IRRIGATION_AC v5/v4 +
+IRRIGATION v5 regression). Full design: `~/.claude/plans/virtual-sniffing-hanrahan.md`.
+
+## What it does
+Supports **AC valves** (24 V AC) switched by **SSRs** — one GPIO per valve, high = open, held while
+open (continuous power). Hardware is **mains-powered, pure-AC**, two valves on **GPIO36/38**. Because
+an open SSR needs the GPIO driven, the node **never deep-sleeps** (deep sleep drops the rail → valve
+closes). It stays awake and reacts to events live — which also makes it the ideal **master valve**
+host: a one-off "run 5 min" mirrored to the master is picked up within a poll interval, not after a
+30-min sleep TTL.
+
+Firmware-only: the node registers as a normal IRRIGATION node (`valve_count=2`). Schedules still live
+in PMU FRAM via `SET_SCHEDULE`, so the API, dashboard, and valve-group mirroring are unchanged — the
+node just *reads and fires* schedules itself.
+
+## Implemented
+- **`ACValveDriver`** (`src/hal/valve_controller.h`): SSR GPIO on/off, `requiresContinuousPower()=true`.
+- **`ValveController`** (`.cpp`): `#ifdef HARDWARE_IRRIGATION_AC` init builds AC drivers + GPIO out,
+  skips H-bridge/indexer; `operateValve` skips indexer select/pulse for continuous-power drivers;
+  `usesContinuousPower()` accessor.
+- **Board pins** (`bramble_v5_pins.h`, `bramble_v4_pins.h`): under `HARDWARE_IRRIGATION_AC`,
+  `NUM_VALVES=2`, `VALVE_PINS={36,38}`; DC defs kept in `#else`.
+- **Build** (`CMakeLists.txt`): `IRRIGATION_AC` variant → `bramble_irrigation_ac*`, defines
+  `HARDWARE_IRRIGATION=1` + `HARDWARE_IRRIGATION_AC=1`; in `ALL`. `main.cpp`: AC info log.
+- **`IrrigationMode`** (all under `#ifdef HARDWARE_IRRIGATION_AC`, DC build byte-identical):
+  - Never sleeps: `signalReadyForSleep()` keeps PMU awake and returns; `VALVE_ACTIVE` keeps awake and
+    advances the SM instead of arming the PMU close-alarm.
+  - `startAlwaysAwakeTasks()` registers periodic `task_manager_` tasks: PMU keepalive (5s),
+    hub update poll (15s, gated on registered+time-synced), schedule eval (20s), auto-close (2s).
+  - `evaluateLocalSchedules()` fires due schedules from a local cache (fed by `SET_SCHEDULE`/
+    `REMOVE_SCHEDULE` updates) against `getUnixTimestamp()`, fire-once per epoch-minute, opens valve
+    for its duration; the auto-close task closes at the deadline.
+
+## Verification done
+Builds clean: `IRRIGATION_AC` (V5, V4) and `IRRIGATION` (V5) regression, SX1262. No warnings/errors.
+
+## Needs bench validation (user flashes)
+The always-awake state-machine integration and SSR timing can only be confirmed on hardware:
+valve 0/1 on GPIO36/38 open and **hold** while running; node never sleeps; auto-close at deadline;
+manual run/stop respond promptly; a stored schedule fires at its time; as a group master, a zone's
+one-off run opens this node's valve quickly. `/bramble-flash IRRIGATION_AC` + `bramble-logs`.
+
+## Known limitations / follow-ups
+- **Boot schedule enumeration:** the local schedule cache is fed by the update stream only. After a
+  reboot, existing PMU-FRAM schedules won't fire until re-pushed by the hub. Follow-up: enumerate via
+  `reliable_pmu_->getSchedule(index, ...)` on boot (bounded), or a hub re-sync on registration.
+- Local cache holds 32 schedules (indices ≥32 are skipped with a warning).
+- Pure-AC only; v3 unsupported (no GPIO36/38); mixed DC+AC not supported.

--- a/src/board/bramble_v4_pins.h
+++ b/src/board/bramble_v4_pins.h
@@ -113,13 +113,25 @@ inline auto API_UART_PORT = uart0;
 constexpr uint API_UART_TX_PIN = J6::PIN_10;  // GPIO 28
 constexpr uint API_UART_RX_PIN = J6::PIN_9;   // GPIO 29
 
-// --- Valve / Motor pins (4 valves on v4, J7 header) ---
-// Valve connector plugs into J7 instead of J6 to free J6 for UART0
-constexpr uint8_t NUM_VALVES = 4;
+// --- Valve / Motor pins (J7 header) ---
+// Valve connector plugs into J7 instead of J6 to free J6 for UART0.
+// H-bridge pins are always defined (DC latching path; unused in an AC build,
+// where GPIO36/38 instead drive the two AC SSR gates directly).
 constexpr uint8_t PIN_MOTOR_HI_1 = J7::PIN_10;  // GPIO 36
 constexpr uint8_t PIN_MOTOR_HI_2 = J7::PIN_8;   // GPIO 38
 constexpr uint8_t PIN_MOTOR_LO_1 = J7::PIN_6;   // GPIO 40
 constexpr uint8_t PIN_MOTOR_LO_2 = J7::PIN_4;   // GPIO 42
+
+#ifdef HARDWARE_IRRIGATION_AC
+// AC variant: two AC valves switched by SSRs on GPIO36/38 (the H-bridge HI
+// pins, repurposed as direct SSR gates). No indexer.
+constexpr uint8_t NUM_VALVES = 2;
+constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
+    36,  // VALVE_1 = SSR gate, silicon GPIO36
+    38,  // VALVE_2 = SSR gate, silicon GPIO38
+};
+#else
+constexpr uint8_t NUM_VALVES = 4;
 // IMPORTANT: these are *silicon* GPIO numbers (what gpio_put() drives), NOT the
 // schematic net labels. The RP2350B sheet names these nets "GPIO37/39/43/41",
 // but those nets physically land on pads GPIO29/31/41/43 — verified against the
@@ -132,6 +144,7 @@ constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
     41,  // VALVE_3 = silicon GPIO41
     43,  // VALVE_4 = silicon GPIO43
 };
+#endif
 
 // --- Curtain motor pins (greenhouse variant, J7 header) ---
 // Relay-based motor reversing: one GPIO per direction

--- a/src/board/bramble_v5_pins.h
+++ b/src/board/bramble_v5_pins.h
@@ -109,12 +109,24 @@ inline auto API_UART_PORT = uart0;
 constexpr uint API_UART_TX_PIN = J6::PIN_10;  // GPIO 28
 constexpr uint API_UART_RX_PIN = J6::PIN_9;   // GPIO 29
 
-// --- Valve / Motor pins (4 valves, J7 header) ---
-constexpr uint8_t NUM_VALVES = 4;
+// --- Valve / Motor pins (J7 header) ---
+// H-bridge pins are always defined (used by the DC latching path; unused in an
+// AC build, where GPIO36/38 instead drive the two AC SSR gates directly).
 constexpr uint8_t PIN_MOTOR_HI_1 = J7::PIN_10;  // GPIO 36
 constexpr uint8_t PIN_MOTOR_HI_2 = J7::PIN_8;   // GPIO 38
 constexpr uint8_t PIN_MOTOR_LO_1 = J7::PIN_6;   // GPIO 40
 constexpr uint8_t PIN_MOTOR_LO_2 = J7::PIN_4;   // GPIO 42
+
+#ifdef HARDWARE_IRRIGATION_AC
+// AC variant: two AC valves switched by SSRs on GPIO36/38 (the H-bridge HI
+// pins, repurposed as direct SSR gates). No indexer.
+constexpr uint8_t NUM_VALVES = 2;
+constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
+    36,  // VALVE_1 = SSR gate, silicon GPIO36
+    38,  // VALVE_2 = SSR gate, silicon GPIO38
+};
+#else
+constexpr uint8_t NUM_VALVES = 4;
 // IMPORTANT: these are *silicon* GPIO numbers (what gpio_put() drives), NOT the
 // schematic net labels. The RP2350B sheet names these nets "GPIO37/39/43/41",
 // but those nets physically land on pads GPIO29/31/41/43 — verified against the
@@ -127,6 +139,7 @@ constexpr uint8_t VALVE_PINS[NUM_VALVES] = {
     41,  // VALVE_3 = silicon GPIO41
     43,  // VALVE_4 = silicon GPIO43
 };
+#endif
 
 // --- Curtain motor pins (greenhouse variant, J7 header) ---
 constexpr uint8_t PIN_CURTAIN_OPEN = J7::PIN_6;   // GPIO 40

--- a/src/hal/valve_controller.cpp
+++ b/src/hal/valve_controller.cpp
@@ -13,6 +13,21 @@ void ValveController::initialize()
 
     log.info("Initializing...");
 
+#ifdef HARDWARE_IRRIGATION_AC
+    // AC SSR valves: one GPIO per valve, driven continuously while open.
+    // No H-bridge or indexer — each SSR is independent.
+    for (uint8_t i = 0; i < NUM_VALVES; i++) {
+        gpio_init(Board::VALVE_PINS[i]);
+        gpio_set_dir(Board::VALVE_PINS[i], GPIO_OUT);
+        gpio_put(Board::VALVE_PINS[i], 0);  // start closed (SSR off)
+        drivers_[i] = std::make_unique<ACValveDriver>(Board::VALVE_PINS[i]);
+        valve_states_[i] = ValveState::UNKNOWN;
+    }
+
+    initialized_ = true;
+
+    log.info("Initialized with %d AC SSR valves", NUM_VALVES);
+#else
     // Initialize H-bridge with board-specific pin mapping
     // For FORWARD: HI_1 + LO_2 active (current flows 1->2)
     // For REVERSE: HI_2 + LO_1 active (current flows 2->1)
@@ -31,6 +46,7 @@ void ValveController::initialize()
     initialized_ = true;
 
     log.info("Initialized with %d valves", NUM_VALVES);
+#endif
 }
 
 void ValveController::openValve(uint8_t valve_id)
@@ -153,15 +169,22 @@ void ValveController::operateValve(uint8_t valve_id, bool open)
 {
     log.info("Operating valve %d: %s", valve_id, open ? "OPEN" : "CLOSE");
 
-    // First ensure ALL valves are deselected to prevent crosstalk
-    indexer_.deselectAll();
-    sleep_us(500);  // Give time for any gate charge to dissipate
+    // AC SSR valves are independent GPIOs (continuous power) — no indexer
+    // select/deselect/pulse sequencing. DC latching valves are multiplexed
+    // through the indexer and pulsed via the H-bridge.
+    const bool continuous = drivers_[valve_id]->requiresContinuousPower();
 
-    // Select the valve
-    indexer_.selectValve(valve_id);
+    if (!continuous) {
+        // First ensure ALL valves are deselected to prevent crosstalk
+        indexer_.deselectAll();
+        sleep_us(500);  // Give time for any gate charge to dissipate
 
-    // Longer delay to ensure MOSFET is fully on and stable
-    sleep_us(1000);  // 1ms for gate to fully charge
+        // Select the valve
+        indexer_.selectValve(valve_id);
+
+        // Longer delay to ensure MOSFET is fully on and stable
+        sleep_us(1000);  // 1ms for gate to fully charge
+    }
 
     // Operate the valve through its driver
     if (open) {
@@ -172,9 +195,11 @@ void ValveController::operateValve(uint8_t valve_id, bool open)
         valve_states_[valve_id] = ValveState::CLOSED;
     }
 
-    // Small delay before deselecting to ensure operation completes
-    sleep_us(500);
+    if (!continuous) {
+        // Small delay before deselecting to ensure operation completes
+        sleep_us(500);
 
-    // Deselect all valves for safety
-    indexer_.deselectAll();
+        // Deselect all valves for safety
+        indexer_.deselectAll();
+    }
 }

--- a/src/hal/valve_controller.h
+++ b/src/hal/valve_controller.h
@@ -3,8 +3,9 @@
 #include <cstdint>
 #include <memory>
 
-#include "hardware/gpio.h"
 #include "pico/critical_section.h"
+
+#include "hardware/gpio.h"
 
 #include "../board/board_pins.h"
 #include "hbridge.h"

--- a/src/hal/valve_controller.h
+++ b/src/hal/valve_controller.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "hardware/gpio.h"
 #include "pico/critical_section.h"
 
 #include "../board/board_pins.h"
@@ -61,6 +62,28 @@ public:
 private:
     HBridge *hbridge_;
     uint32_t pulse_duration_ms_;
+};
+
+/**
+ * @brief AC solenoid valve driver (SSR-switched)
+ *
+ * One GPIO per valve drives a solid-state relay: high = SSR on = valve open.
+ * The valve stays open only while the GPIO is driven, so these valves require
+ * continuous power (the node must not sleep while one is open). No H-bridge or
+ * valve indexer — each SSR is independent and several may be on simultaneously.
+ */
+class ACValveDriver : public ValveDriver {
+public:
+    explicit ACValveDriver(uint8_t gpio_pin) : pin_(gpio_pin) {}
+
+    void open() override { gpio_put(pin_, 1); }
+    void close() override { gpio_put(pin_, 0); }
+
+    bool requiresContinuousPower() override { return true; }
+    ValveType getType() override { return ValveType::AC_SOLENOID; }
+
+private:
+    uint8_t pin_;
 };
 
 /**
@@ -141,6 +164,18 @@ public:
      * @return Bitmask where bit N is 1 if valve N is open
      */
     uint8_t getActiveValveMask() const;
+
+    /**
+     * @brief Whether this controller's valves require continuous power
+     *
+     * True for AC SSR valves (the node must stay awake while any valve is
+     * open), false for DC latching valves. A node is pure-AC or pure-DC, so
+     * valve 0's driver is representative.
+     */
+    bool usesContinuousPower() const
+    {
+        return initialized_ && drivers_[0] && drivers_[0]->requiresContinuousPower();
+    }
 
     /**
      * @brief Set valve type (for future AC valve support)

--- a/src/modes/irrigation_mode.cpp
+++ b/src/modes/irrigation_mode.cpp
@@ -18,6 +18,13 @@
 constexpr uint16_t HUB_ADDRESS = ADDRESS_HUB;
 constexpr uint32_t HEARTBEAT_INTERVAL_MS = 60000;  // 60 seconds
 
+#ifdef HARDWARE_IRRIGATION_AC
+// Always-awake AC node cadences.
+constexpr uint32_t AC_UPDATE_POLL_INTERVAL_MS = 15000;    // poll hub for commands/updates
+constexpr uint32_t AC_SCHEDULE_EVAL_INTERVAL_MS = 20000;  // evaluate schedules (< 60s)
+constexpr uint32_t AC_VALVE_CLOSE_INTERVAL_MS = 2000;     // auto-close granularity
+#endif
+
 // PMU UART configuration - selected by board version via board_pins.h
 #include "../board/board_pins.h"
 
@@ -169,10 +176,19 @@ void IrrigationMode::onStart()
                                      active_sensors, error_flags, 0, device_id_);
         },
         HEARTBEAT_INTERVAL_MS, "Heartbeat");
+
+#ifdef HARDWARE_IRRIGATION_AC
+    startAlwaysAwakeTasks();
+#endif
 }
 
 void IrrigationMode::onStateChange(IrrigationState state)
 {
+    // Re-arm (or clear) the per-state watchdog before running the state's side
+    // effects, so a state that never gets its expected response recovers instead
+    // of stranding the cycle.
+    armStateWatchdog(state);
+
     switch (state) {
         case IrrigationState::REGISTERING:
             if (needs_registration_) {
@@ -226,6 +242,17 @@ void IrrigationMode::onStateChange(IrrigationState state)
             break;
 
         case IrrigationState::VALVE_ACTIVE: {
+#ifdef HARDWARE_IRRIGATION_AC
+            // AC mains node: the valve GPIO is held because the node never
+            // sleeps. Don't arm the PMU close-alarm; the periodic auto-close
+            // task closes the valve at its deadline. Advance the SM out of
+            // VALVE_ACTIVE (signalReadyForSleep is a no-op for AC).
+            if (pmu_available_ && reliable_pmu_) {
+                reliable_pmu_->keepAwake(KEEP_AWAKE_PROCESSING_SECONDS);
+            }
+            irrigation_state_.reportValveTimerSet();
+            break;
+#endif
             // If anything in the deadline queue is pending, arm the PMU's
             // RTC Alarm A for the soonest deadline. Otherwise fall back to
             // keepAlive (legacy: valve opened with no duration).
@@ -299,6 +326,135 @@ void IrrigationMode::scheduleKeepAwake()
         },
         now, 5000, TaskPriority::High);
 }
+
+uint32_t IrrigationMode::stateWatchdogMs(IrrigationState state)
+{
+    // Budgets must exceed the messenger's full delivery window for the message
+    // each state waits on, or the watchdog aborts a cycle that would still have
+    // succeeded — and a late reply then lands out of state (the warning we're
+    // trying to remove). RELIABLE = 3 tries, backoff 2/4/8s, gives up ~16s.
+    switch (state) {
+        case IrrigationState::REGISTERING:
+        case IrrigationState::AWAITING_REGISTRATION:
+            return 18000;  // Registration request is RELIABLE (~16s give-up)
+        case IrrigationState::AWAITING_TIME:
+            return 3000;  // No I/O — transitions to SENDING_HEARTBEAT immediately
+        case IrrigationState::SENDING_HEARTBEAT:
+            return 5000;  // Heartbeat is BEST_EFFORT (one shot); 5s to see the response
+        case IrrigationState::CHECKING_UPDATES:
+            return 18000;  // CHECK_UPDATES is RELIABLE (~16s give-up, no failure callback)
+        case IrrigationState::APPLYING_UPDATE:
+            return 10000;  // Local PMU schedule/datetime write plus its callback
+        default:
+            // Parked or self-healing states get no watchdog:
+            // READY_FOR_SLEEP / VALVE_ACTIVE are intentionally long-lived, and
+            // TRANSMITTING_EVENTS already self-advances via its own drain timeout
+            // (reportWatchdogTimeout can't recover it — it targets that state).
+            return 0;
+    }
+}
+
+void IrrigationMode::armStateWatchdog(IrrigationState state)
+{
+    if (state_watchdog_id_ != 0) {
+        task_queue_.cancel(state_watchdog_id_);
+        state_watchdog_id_ = 0;
+    }
+    const uint32_t watchdog_ms = stateWatchdogMs(state);
+    if (watchdog_ms == 0) {
+        return;
+    }
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    state_watchdog_id_ = task_queue_.postDelayed(
+        [this](uint32_t) -> bool {
+            state_watchdog_id_ = 0;
+            irrigation_state_.reportWatchdogTimeout();
+            return true;
+        },
+        now, watchdog_ms, TaskPriority::High);
+}
+
+#ifdef HARDWARE_IRRIGATION_AC
+void IrrigationMode::startAlwaysAwakeTasks()
+{
+    logger.info("AC node: starting always-awake tasks (keepalive/poll/schedule/close)");
+
+    // Keep the PMU powered so it never cuts the main rail (which would drop an
+    // open SSR valve). KEEP_AWAKE is 10s; renew well inside that.
+    task_manager_.addTask(
+        [this](uint32_t) {
+            if (pmu_available_ && reliable_pmu_) {
+                reliable_pmu_->keepAwake(KEEP_AWAKE_PROCESSING_SECONDS);
+            }
+        },
+        5000, "ACKeepalive");
+
+    // Poll the hub for queued commands/updates (manual run/stop, schedule
+    // changes, group-mirrored master opens) — low latency since we never sleep.
+    // Drive the state machine through a full service cycle (heartbeat ->
+    // CHECKING_UPDATES -> apply -> sleep) rather than calling sendCheckUpdates()
+    // behind its back: that lets the SM own state and process updates in the
+    // CHECKING_UPDATES/APPLYING_UPDATE states the rest of the code expects.
+    // reportServiceTick() is a no-op unless the SM is parked, so it never
+    // interrupts an open valve or an in-flight update. Skip until registered
+    // and time-synced.
+    task_manager_.addTask(
+        [this](uint32_t) {
+            if (messenger_.getNodeAddress() != ADDRESS_UNREGISTERED && getUnixTimestamp() != 0) {
+                irrigation_state_.reportServiceTick();
+            }
+        },
+        AC_UPDATE_POLL_INTERVAL_MS, "ACPoll");
+
+    // Fire due schedules locally — the PMU only fires schedules by cold-waking a
+    // sleeping node, which never happens here.
+    task_manager_.addTask([this](uint32_t) { evaluateLocalSchedules(); },
+                          AC_SCHEDULE_EVAL_INTERVAL_MS, "ACSchedule");
+
+    // Auto-close valves whose deadlines have passed (no PMU RTC alarm involved).
+    task_manager_.addTask([this](uint32_t) { processExpiredValveDeadlines(); },
+                          AC_VALVE_CLOSE_INTERVAL_MS, "ACClose");
+}
+
+void IrrigationMode::evaluateLocalSchedules()
+{
+    uint32_t now = getUnixTimestamp();
+    if (now == 0) {
+        return;  // no wall-clock yet
+    }
+
+    const uint32_t now_min = now / 60;
+    const uint8_t hour = (now % 86400) / 3600;
+    const uint8_t minute = (now % 3600) / 60;
+    // Unix epoch (1970-01-01) was a Thursday; day-of-week bit 0 = Sunday.
+    const uint8_t dow = static_cast<uint8_t>(((now / 86400) + 4) % 7);
+
+    for (uint8_t i = 0; i < AC_SCHEDULE_CACHE; i++) {
+        if (!ac_schedule_valid_[i]) {
+            continue;
+        }
+        const PMU::ScheduleEntry &s = ac_schedule_[i];
+        if (!s.enabled || s.hour != hour || s.minute != minute) {
+            continue;
+        }
+        if (((static_cast<uint8_t>(s.daysMask) >> dow) & 0x01) == 0) {
+            continue;  // not scheduled today
+        }
+        if (ac_schedule_last_fired_min_[i] == now_min) {
+            continue;  // already fired this occurrence
+        }
+        if (s.valveId >= ValveController::NUM_VALVES) {
+            continue;
+        }
+
+        ac_schedule_last_fired_min_[i] = now_min;
+        logger.info("AC schedule[%u] fire: valve %u for %us", i, s.valveId, s.duration);
+        valve_controller_.openValve(s.valveId);
+        event_log_.record(EventType::VALVE_OPEN, 0, s.valveId);
+        valve_close_deadlines_[s.valveId] = (s.duration > 0) ? (now + s.duration) : 0;
+    }
+}
+#endif  // HARDWARE_IRRIGATION_AC
 
 void IrrigationMode::handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEntry *entry,
                                    bool state_valid, const uint8_t *state, bool valve_reset)
@@ -547,6 +703,19 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
                         entry.hour, entry.minute, entry.valveId, entry.duration,
                         static_cast<uint8_t>(entry.daysMask));
 
+#ifdef HARDWARE_IRRIGATION_AC
+            // Cache locally so the always-awake node can fire it itself (the PMU
+            // only fires schedules by cold-waking a sleeping node).
+            if (index < AC_SCHEDULE_CACHE) {
+                ac_schedule_[index] = entry;
+                ac_schedule_valid_[index] = true;
+                ac_schedule_last_fired_min_[index] = 0;
+            } else {
+                logger.warn("  Schedule index %d exceeds AC local cache (%d)", index,
+                            AC_SCHEDULE_CACHE);
+            }
+#endif
+
             reliable_pmu_->setSchedule(
                 index, entry, [this, hub_sequence, index](bool success, PMU::ErrorCode error) {
                     if (success) {
@@ -568,6 +737,12 @@ void IrrigationMode::onModeSpecificUpdate(const UpdateAvailablePayload *payload,
         case UpdateType::REMOVE_SCHEDULE: {
             uint8_t index = payload->payload_data[0];
             logger.info("  REMOVE_SCHEDULE[%d]", index);
+
+#ifdef HARDWARE_IRRIGATION_AC
+            if (index < AC_SCHEDULE_CACHE) {
+                ac_schedule_valid_[index] = false;
+            }
+#endif
 
             reliable_pmu_->clearSchedule(index, [this, hub_sequence, index](bool success,
                                                                             PMU::ErrorCode error) {
@@ -678,6 +853,15 @@ void IrrigationMode::signalReadyForSleep()
         logger.debug("PMU not available, skipping ready for sleep signal");
         return;
     }
+
+#ifdef HARDWARE_IRRIGATION_AC
+    // Mains AC node: never sleep (deep sleep would drop the SSR GPIO and close
+    // an open valve). Keep the PMU powered; the periodic always-awake tasks keep
+    // the node serviced. The state machine parks here harmlessly until the next
+    // valve/command event.
+    reliable_pmu_->keepAwake(KEEP_AWAKE_PROCESSING_SECONDS);
+    return;
+#endif
 
     task_queue_.post(
         [this](uint32_t) -> bool {

--- a/src/modes/irrigation_mode.h
+++ b/src/modes/irrigation_mode.h
@@ -65,6 +65,7 @@ private:
     uint16_t wake_timeout_id_ = 0;
     uint16_t keepawake_task_id_ = 0;
     uint16_t drain_task_id_ = 0;
+    uint16_t state_watchdog_id_ = 0;
     uint32_t drain_start_ms_ = 0;
     // Per-valve auto-close deadlines as absolute unix timestamps.
     // 0 = no pending close. Array index = valve_id. The PMU's single RTC
@@ -79,6 +80,14 @@ private:
     void onStateChange(IrrigationState state);
 
     void scheduleKeepAwake();
+
+    /// Per-state safety net: re-arm a one-shot timer on entering a transient
+    /// state so a silent hub can't strand the cycle. Cancels any prior timer;
+    /// parked/long-lived states (READY_FOR_SLEEP, VALVE_ACTIVE) arm nothing.
+    /// On expiry, reportWatchdogTimeout() forces the cycle back to sleep.
+    void armStateWatchdog(IrrigationState state);
+    /// Watchdog budget per state in ms; 0 means "no watchdog for this state".
+    static uint32_t stateWatchdogMs(IrrigationState state);
 
     // PMU callback handlers
     void handlePmuWake(PMU::WakeReason reason, const PMU::ScheduleEntry *entry, bool state_valid,
@@ -110,6 +119,25 @@ private:
     void armNextValveTimer();
     /// Close any valves whose deadlines have passed. Called from handlePmuWake.
     void processExpiredValveDeadlines();
+
+#ifdef HARDWARE_IRRIGATION_AC
+    // --- AC valve node: mains-powered, always-awake ---
+    // AC SSR valves need continuous power, so the node never deep-sleeps (deep
+    // sleep would drop the SSR GPIO and close the valve). Instead it keeps the
+    // PMU powered, polls for commands/updates, fires schedules locally, and
+    // auto-closes valves on a local timer — all via periodic task_manager tasks.
+    static constexpr uint8_t AC_SCHEDULE_CACHE = 32;
+    PMU::ScheduleEntry ac_schedule_[AC_SCHEDULE_CACHE];
+    bool ac_schedule_valid_[AC_SCHEDULE_CACHE] = {false};
+    uint32_t ac_schedule_last_fired_min_[AC_SCHEDULE_CACHE] = {0};
+
+    /// Register the always-awake periodic tasks (keepalive, update poll,
+    /// schedule evaluation, auto-close). Called from onStart for the AC build.
+    void startAlwaysAwakeTasks();
+    /// Fire any schedules in the local cache whose time matches now (fire-once
+    /// per occurrence), opening the valve for its duration.
+    void evaluateLocalSchedules();
+#endif
 
 public:
     using ApplicationMode::ApplicationMode;

--- a/src/util/irrigation_state_machine.cpp
+++ b/src/util/irrigation_state_machine.cpp
@@ -174,6 +174,16 @@ void IrrigationStateMachine::reportWakeFromSleep(PMU::WakeReason reason)
     }
 }
 
+void IrrigationStateMachine::reportServiceTick()
+{
+    if (state_ != IrrigationState::READY_FOR_SLEEP) {
+        logger.debug("Service tick ignored - cycle already active (state: %s)", stateName(state_));
+        return;
+    }
+    logger.info("Service tick - starting heartbeat/update cycle");
+    transitionTo(IrrigationState::AWAITING_TIME);
+}
+
 void IrrigationStateMachine::reportWatchdogTimeout()
 {
     logger.warn("State watchdog timeout in %s - forcing sleep", stateName(state_));

--- a/src/util/irrigation_state_machine.h
+++ b/src/util/irrigation_state_machine.h
@@ -223,6 +223,19 @@ public:
     void reportWakeFromSleep(PMU::WakeReason reason);
 
     /**
+     * @brief Begin a servicing cycle on an always-awake (AC) node.
+     *
+     * AC nodes never sleep, so they have no PMU wake to drive the heartbeat/
+     * update cycle. Instead a periodic timer calls this to re-enter the cycle
+     * from its parked state, driving the same path a wake would:
+     * READY_FOR_SLEEP -> AWAITING_TIME (-> heartbeat -> CHECKING_UPDATES -> ...).
+     *
+     * No-op (logged at debug) in any other state, so it never interrupts an
+     * in-flight update or an open valve.
+     */
+    void reportServiceTick();
+
+    /**
      * @brief Report that a per-state watchdog fired (generic timeout)
      *
      * Forces transition to READY_FOR_SLEEP from any state.

--- a/valve_test.cpp
+++ b/valve_test.cpp
@@ -9,7 +9,11 @@
  * Intended for probing the valve drive path with a DMM — no LoRa, PMU, or
  * hub registration so it never blocks on the bench.
  *
- * Build:  cmake -B build -DHARDWARE_VARIANT=VALVETEST -DBOARD_VERSION=V4
+ * DC build:  cmake -B build -DHARDWARE_VARIANT=VALVETEST -DBOARD_VERSION=V4
+ * AC build:  cmake -B build -DHARDWARE_VARIANT=VALVETEST_AC -DBOARD_VERSION=V5
+ *
+ * The AC build (HARDWARE_IRRIGATION_AC) drives one SSR gate per valve directly;
+ * there is no H-bridge or indexer, but the open-5s-close sweep is identical.
  */
 #include "pico/stdlib.h"
 
@@ -34,7 +38,14 @@ int main()
                 static_cast<unsigned long>(VALVE_ON_DURATION_MS));
 
     // Print the full pin map so the bench observation can be correlated to silicon
-    // GPIOs. Each valve id selects one VALVE_PINS line; the shared H-bridge then
+    // GPIOs.
+#ifdef HARDWARE_IRRIGATION_AC
+    // AC: each valve id drives its own SSR gate GPIO high (open) / low (close).
+    for (uint8_t i = 0; i < ValveController::NUM_VALVES; i++) {
+        logger.info("  id %u -> SSR gate GPIO %u (high=open)", i, Board::VALVE_PINS[i]);
+    }
+#else
+    // DC: each valve id selects one VALVE_PINS line; the shared H-bridge then
     // pulses FORWARD (open) or REVERSE (close).
     logger.info("H-bridge: HI_1=%u LO_1=%u HI_2=%u LO_2=%u (FORWARD=HI_1+LO_2, REVERSE=HI_2+LO_1)",
                 Board::PIN_MOTOR_HI_1, Board::PIN_MOTOR_LO_1, Board::PIN_MOTOR_HI_2,
@@ -42,6 +53,7 @@ int main()
     for (uint8_t i = 0; i < ValveController::NUM_VALVES; i++) {
         logger.info("  id %u -> select GPIO %u", i, Board::VALVE_PINS[i]);
     }
+#endif
 
     ValveController valve_controller;
     valve_controller.initialize();


### PR DESCRIPTION
Adds an always-awake, mains-powered irrigation node for AC solenoid valves switched by solid-state relays, alongside the existing DC latching valve path.

## What's new
- **`ACValveDriver`** — one GPIO per valve drives an SSR (high = open). Reports `requiresContinuousPower()` so the node never deep-sleeps while a valve is open (sleep would drop the SSR gate and close the valve).
- **`valve_controller`** — AC init path (independent GPIOs, no H-bridge/indexer); `operateValve()` skips the indexer select/deselect/pulse sequencing for continuous-power valves.
- **`irrigation_mode` (`HARDWARE_IRRIGATION_AC`)** — never-sleep operation: periodic keepalive, update polling, local schedule evaluation, and timer-based auto-close, in place of PMU scheduled wakes.
- **State machine** — `reportServiceTick()` re-enters the heartbeat/update cycle from `READY_FOR_SLEEP` for nodes that have no PMU wake to drive it.
- **v4/v5 pins** — AC build maps 2 SSR gates onto GPIO36/38 (the H-bridge HI pins, repurposed as direct SSR gates).
- **CMakeLists** — new `IRRIGATION_AC` and `VALVETEST_AC` build variants.

## Notes
- A node is pure-AC or pure-DC; the AC path is selected at compile time via `HARDWARE_IRRIGATION_AC`.
- `VERSION`, KiCad `.kicad_prl` editor-state, and build dirs are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)