### PR TITLE
feat(api): fail-loud serial link health + stable hub port default

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -60,23 +60,44 @@ def get_serial() -> SerialInterface:
     return serial_interface
 
 
-@app.route('/api/health', methods=['GET'])
-def health():
-    """Health check endpoint."""
+def _link_status() -> dict:
+    """Best-effort serial link status; never raises.
+
+    Reads the existing interface without forcing a connect, so it is safe to
+    call from health checks and the nodes endpoint.
+    """
+    down = {'connected': False, 'last_rx_age_seconds': None, 'healthy': False}
     try:
-        serial = get_serial()
-        connected = serial.serial and serial.serial.is_open
-        return jsonify({
-            'status': 'healthy' if connected else 'degraded',
-            'serial_connected': connected,
-            'serial_port': Config.SERIAL_PORT
-        })
-    except Exception as e:
-        logger.error(f"Health check failed: {e}")
-        return jsonify({
-            'status': 'unhealthy',
-            'error': str(e)
-        }), 503
+        if serial_interface is None:
+            return down
+        return serial_interface.link_status()
+    except Exception:
+        return down
+
+
+@app.route('/api/health', methods=['GET'])
+@app.route('/healthz', methods=['GET'])
+def health():
+    """Fail-loud health check.
+
+    Returns 503 (not 200) when the serial link to the hub is down or stale, so
+    a dead link surfaces instead of being masked behind stale data.
+    """
+    link = _link_status()
+    if link['healthy']:
+        status = 'healthy'
+    elif link['connected']:
+        status = 'degraded'
+    else:
+        status = 'down'
+    payload = {
+        'status': status,
+        'serial_connected': link['connected'],
+        'serial_link_up': link['healthy'],
+        'last_sync_age_seconds': link['last_rx_age_seconds'],
+        'serial_port': Config.SERIAL_PORT,
+    }
+    return jsonify(payload), (200 if link['healthy'] else 503)
 
 
 @app.route('/api/system/time', methods=['GET'])
@@ -158,10 +179,13 @@ def _build_nodes_from_database():
         node_dict['status'] = status
         nodes.append(node_dict)
 
+    link = _link_status()
     return jsonify({
         'count': len(nodes),
         'nodes': nodes,
-        'source': 'database'
+        'source': 'database',
+        'link_up': link['healthy'],
+        'last_sync_age_seconds': link['last_rx_age_seconds'],
     })
 
 
@@ -438,10 +462,13 @@ def list_nodes():
                         node_dict['hub_queue_count'] = _get_hub_queue_count(serial, address)
                     nodes.append(node_dict)
 
+        link = _link_status()
         return jsonify({
             'count': count,
             'nodes': nodes,
-            'source': 'hub'
+            'source': 'hub',
+            'link_up': link['healthy'],
+            'last_sync_age_seconds': link['last_rx_age_seconds'],
         })
 
     except Exception as e:

--- a/api/config.py
+++ b/api/config.py
@@ -14,14 +14,22 @@ class Config:
     # the iOS widget). Empty disables enforcement — preserving local/dev access.
     API_TOKEN = os.getenv('API_TOKEN', '')
 
-    # Serial settings
-    SERIAL_PORT = os.getenv('SERIAL_PORT', '/dev/ttyAMA0')
+    # Serial settings. The port is addressed via a stable udev symlink
+    # (/dev/bramble-hub) so kernel UART renumbering can't break it; see the
+    # 99-bramble-hub.rules udev rule on the hub.
+    SERIAL_PORT = os.getenv('SERIAL_PORT', '/dev/bramble-hub')
     SERIAL_BAUD = int(os.getenv('SERIAL_BAUD', '115200'))
     SERIAL_TIMEOUT = float(os.getenv('SERIAL_TIMEOUT', '1.0'))
 
     # Hub communication settings
     COMMAND_TIMEOUT = float(os.getenv('COMMAND_TIMEOUT', '5.0'))
     MAX_RETRIES = int(os.getenv('MAX_RETRIES', '3'))
+
+    # Serial link is considered stale (effectively down) if no line has been
+    # received from the hub within this many seconds. The hub emits GET_DATETIME
+    # and heartbeats continuously, so a gap this long means the link is dead even
+    # if the OS still reports the port as open.
+    LINK_STALE_SECONDS = float(os.getenv('LINK_STALE_SECONDS', '60'))
 
     # Database settings
     SENSOR_DB_PATH = os.getenv('SENSOR_DB_PATH', '/data/sensor_data.duckdb')

--- a/api/serial_interface.py
+++ b/api/serial_interface.py
@@ -43,6 +43,10 @@ class SerialInterface:
         self.database = database
         self._batch_state: Optional[dict] = None  # Tracks in-progress batch
 
+        # Liveness: wall-clock time of the last line received from the hub.
+        # Used by link_status() for fail-loud health checks.
+        self.last_hub_rx_time: Optional[float] = None
+
     def connect(self):
         """Open serial connection to hub."""
         try:
@@ -131,12 +135,36 @@ class SerialInterface:
         "EVENT_LOG ", "EVENT ",
     ]
 
+    def link_status(self) -> dict:
+        """Report serial link liveness for fail-loud health checks.
+
+        'healthy' means the port is open AND a line was received from the hub
+        within Config.LINK_STALE_SECONDS. Because the hub streams GET_DATETIME
+        and heartbeats continuously, a longer silence means the link is
+        effectively down even when the OS still reports the port as open.
+
+        Returns:
+            dict with 'connected', 'last_rx_age_seconds' (None if never), and
+            'healthy'.
+        """
+        connected = bool(self.serial and self.serial.is_open and self.running)
+        last_rx = self.last_hub_rx_time
+        age = (time.time() - last_rx) if last_rx is not None else None
+        healthy = connected and age is not None and age <= Config.LINK_STALE_SECONDS
+        return {
+            'connected': connected,
+            'last_rx_age_seconds': round(age, 1) if age is not None else None,
+            'healthy': healthy,
+        }
+
     def _handle_line(self, line: str):
         """Process a line received from the hub.
 
         Args:
             line: Complete line from hub
         """
+        # Any line from the hub proves the link is alive (liveness signal).
+        self.last_hub_rx_time = time.time()
         logger.debug(f"Hub: {line}")
 
         # Check if line contains an embedded message (corruption recovery).


### PR DESCRIPTION
## Context

A multi-hour outage where the hub appeared offline turned out to be the Pi's UART device node renumbering after a kernel/firmware update: the GPIO14/15 UART moved from `/dev/ttyAMA0` to `/dev/ttyAMA2` (the `uart2-pi5` overlay), but the API was still pointed at `ttyAMA0`. The expensive part wasn't the wiring — it was that **the outage was invisible**: `/api/nodes` fell back to stale DB data and still returned `200`, and `/api/health` returned `200` even when degraded.

Infra fixes (stable `/dev/bramble-hub` udev symlink + single-source compose config) were applied on the hub directly. This PR is the **fail-loud** half so the next outage surfaces at a glance.

## Changes

- **Liveness tracking** — `SerialInterface` records the time of the last line received from the hub and exposes `link_status()`. The hub streams `GET_DATETIME`/heartbeats continuously, so RX-age is the truest liveness signal; `healthy` = port open AND a line seen within `LINK_STALE_SECONDS` (default 60s).
- **`/api/health` + new `/healthz`** now return **503** (not 200) when the link is down or stale, with `last_sync_age_seconds` in the payload.
- **`/api/nodes`** reports `link_up` + `last_sync_age_seconds` on both the `hub` and `database` paths, so a stale/fallback response is visible to clients (dashboard can show a banner).
- **Default `SERIAL_PORT`** is now the stable `/dev/bramble-hub` udev symlink so kernel UART renumbering can't silently break the link again.

## Test

- `python3 -m py_compile` passes on all three files.
- Hub link verified healthy end-to-end on the Pi after the infra fix (`/api/nodes` → `source: hub`, 0 timeouts).
- Post-merge: rebuild/redeploy the `api` image; confirm `/healthz` → 200 when up, and that pulling the hub link flips it to 503 with `source: database` on `/api/nodes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)